### PR TITLE
1. add at_framework to gcc makefile

### DIFF
--- a/components/connectivity/at_frame/atadapter.c
+++ b/components/connectivity/at_frame/atadapter.c
@@ -13,7 +13,7 @@ int32_t at_get_unuse_linkid();
 void at_listener_list_add(at_listener * p);
 void at_listner_list_del(at_listener * p);
 int32_t at_cmd(int8_t * cmd, int32_t len, const char * suffix, char * rep_buf);
-int at_oob_register(char* cmd,int cmdlen, oob_callback callback);
+int32_t at_oob_register(char* featurestr,int cmdlen, oob_callback callback);
 
 //init function for at struct
 at_task at = {
@@ -115,7 +115,7 @@ int32_t at_write(int8_t * cmd, int8_t * suffix, int8_t * buf, int32_t len)
     at_listener_list_add(&listener);
 
     at_transmit((uint8_t*)cmd, strlen((char*)cmd), 1);
-    osDelay(osMs2Tick(200));
+    LOS_TaskDelay(200);
 
     at_transmit((uint8_t*)buf, len, 0);
     ret = LOS_SemPend(at.resp_sem, at.timeout);
@@ -239,7 +239,7 @@ uint32_t create_at_recv_task()
 void at_init_oob(void)
 {
     at_oob.oob_num = 0;
-    memset(at_oob.oob,0,5*sizeof(struct oob_s));
+    memset(at_oob.oob,0,OOB_MAX_NUM * sizeof(struct oob_s));
 }
 
 int32_t at_struct_init(at_task * at)

--- a/targets/STM32F429IGTx_FIRE/EWARM/Huawei_LiteOS.ewd
+++ b/targets/STM32F429IGTx_FIRE/EWARM/Huawei_LiteOS.ewd
@@ -48,7 +48,7 @@
                 </option>
                 <option>
                     <name>RunToEnable</name>
-                    <state>0</state>
+                    <state>1</state>
                 </option>
                 <option>
                     <name>RunToName</name>
@@ -76,11 +76,11 @@
                 </option>
                 <option>
                     <name>OCDownloadVerifyAll</name>
-                    <state>1</state>
+                    <state>0</state>
                 </option>
                 <option>
                     <name>OCProductVersion</name>
-                    <state>8.20.2.14834</state>
+                    <state>8.22.2.15993</state>
                 </option>
                 <option>
                     <name>OCDynDriverList</name>
@@ -88,7 +88,7 @@
                 </option>
                 <option>
                     <name>OCLastSavedByProductVersion</name>
-                    <state>8.20.1.14181</state>
+                    <state>8.22.2.15993</state>
                 </option>
                 <option>
                     <name>UseFlashLoader</name>
@@ -950,6 +950,27 @@
             </data>
         </settings>
         <settings>
+            <name>NULINK_ID</name>
+            <archiveVersion>2</archiveVersion>
+            <data>
+                <version>0</version>
+                <wantNonLocal>1</wantNonLocal>
+                <debug>1</debug>
+                <option>
+                    <name>OCDriverInfo</name>
+                    <state>1</state>
+                </option>
+                <option>
+                    <name>DoLogfile</name>
+                    <state>0</state>
+                </option>
+                <option>
+                    <name>LogFile</name>
+                    <state>$PROJ_DIR$\cspycomm.log</state>
+                </option>
+            </data>
+        </settings>
+        <settings>
             <name>PEMICRO_ID</name>
             <archiveVersion>2</archiveVersion>
             <data>
@@ -978,7 +999,7 @@
             <name>STLINK_ID</name>
             <archiveVersion>2</archiveVersion>
             <data>
-                <version>4</version>
+                <version>5</version>
                 <wantNonLocal>1</wantNonLocal>
                 <debug>1</debug>
                 <option>
@@ -1085,6 +1106,10 @@
                 </option>
                 <option>
                     <name>CCSTLinkDebugAccessPortRadio</name>
+                    <state>0</state>
+                </option>
+                <option>
+                    <name>CCSTLinkUseServerSelect</name>
                     <state>0</state>
                 </option>
             </data>
@@ -1367,6 +1392,10 @@
                 <loadFlag>0</loadFlag>
             </plugin>
             <plugin>
+                <file>$TOOLKIT_DIR$\plugins\rtos\FreeRtos\FreeRtosArmPlugin.ENU.ewplugin</file>
+                <loadFlag>0</loadFlag>
+            </plugin>
+            <plugin>
                 <file>$TOOLKIT_DIR$\plugins\rtos\Mbed\MbedArmPlugin.ENU.ewplugin</file>
                 <loadFlag>0</loadFlag>
             </plugin>
@@ -1376,6 +1405,14 @@
             </plugin>
             <plugin>
                 <file>$TOOLKIT_DIR$\plugins\rtos\SafeRTOS\SafeRTOSPlugin.ewplugin</file>
+                <loadFlag>0</loadFlag>
+            </plugin>
+            <plugin>
+                <file>$TOOLKIT_DIR$\plugins\rtos\SMX\smxAwareIarArm8.ewplugin</file>
+                <loadFlag>0</loadFlag>
+            </plugin>
+            <plugin>
+                <file>$TOOLKIT_DIR$\plugins\rtos\SMX\smxAwareIarArm8BE.ewplugin</file>
                 <loadFlag>0</loadFlag>
             </plugin>
             <plugin>
@@ -2365,6 +2402,27 @@
             </data>
         </settings>
         <settings>
+            <name>NULINK_ID</name>
+            <archiveVersion>2</archiveVersion>
+            <data>
+                <version>0</version>
+                <wantNonLocal>1</wantNonLocal>
+                <debug>0</debug>
+                <option>
+                    <name>OCDriverInfo</name>
+                    <state>1</state>
+                </option>
+                <option>
+                    <name>DoLogfile</name>
+                    <state>0</state>
+                </option>
+                <option>
+                    <name>LogFile</name>
+                    <state>$PROJ_DIR$\cspycomm.log</state>
+                </option>
+            </data>
+        </settings>
+        <settings>
             <name>PEMICRO_ID</name>
             <archiveVersion>2</archiveVersion>
             <data>
@@ -2393,7 +2451,7 @@
             <name>STLINK_ID</name>
             <archiveVersion>2</archiveVersion>
             <data>
-                <version>4</version>
+                <version>5</version>
                 <wantNonLocal>1</wantNonLocal>
                 <debug>0</debug>
                 <option>
@@ -2500,6 +2558,10 @@
                 </option>
                 <option>
                     <name>CCSTLinkDebugAccessPortRadio</name>
+                    <state>0</state>
+                </option>
+                <option>
+                    <name>CCSTLinkUseServerSelect</name>
                     <state>0</state>
                 </option>
             </data>
@@ -2782,6 +2844,10 @@
                 <loadFlag>0</loadFlag>
             </plugin>
             <plugin>
+                <file>$TOOLKIT_DIR$\plugins\rtos\FreeRtos\FreeRtosArmPlugin.ENU.ewplugin</file>
+                <loadFlag>0</loadFlag>
+            </plugin>
+            <plugin>
                 <file>$TOOLKIT_DIR$\plugins\rtos\Mbed\MbedArmPlugin.ENU.ewplugin</file>
                 <loadFlag>0</loadFlag>
             </plugin>
@@ -2791,6 +2857,14 @@
             </plugin>
             <plugin>
                 <file>$TOOLKIT_DIR$\plugins\rtos\SafeRTOS\SafeRTOSPlugin.ewplugin</file>
+                <loadFlag>0</loadFlag>
+            </plugin>
+            <plugin>
+                <file>$TOOLKIT_DIR$\plugins\rtos\SMX\smxAwareIarArm8.ewplugin</file>
+                <loadFlag>0</loadFlag>
+            </plugin>
+            <plugin>
+                <file>$TOOLKIT_DIR$\plugins\rtos\SMX\smxAwareIarArm8BE.ewplugin</file>
                 <loadFlag>0</loadFlag>
             </plugin>
             <plugin>

--- a/targets/STM32F429IGTx_FIRE/EWARM/Huawei_LiteOS.ewp
+++ b/targets/STM32F429IGTx_FIRE/EWARM/Huawei_LiteOS.ewp
@@ -66,7 +66,7 @@
                 </option>
                 <option>
                     <name>OGLastSavedByProductVersion</name>
-                    <state>8.22.1.15696</state>
+                    <state>8.22.2.15993</state>
                 </option>
                 <option>
                     <name>GeneralEnableMisra</name>
@@ -219,12 +219,12 @@
                     <state>USE_HAL_DRIVER</state>
                     <state>USE_MBED_TLS</state>
                     <state>MBEDTLS_CONFIG_FILE=&lt;los_mbedtls_config.h&gt;</state>
-                    <state>WITH_LWIP</state>
                     <state>LWM2M_LITTLE_ENDIAN</state>
                     <state>LWM2M_CLIENT_MODE</state>
                     <state>NDEBUG</state>
                     <state>WITH_DTLS</state>
                     <state>_DLIB_FILE_DESCRIPTOR</state>
+                    <state>WITH_LWIP</state>
                 </option>
                 <option>
                     <name>CCPreprocFile</name>
@@ -377,6 +377,10 @@
                     <state>$PROJ_DIR$\..\..\..\components\connectivity\agent_tiny\examples</state>
                     <state>$PROJ_DIR$\..\..\..\components\connectivity\agent_tiny\osadapter</state>
                     <state>$PROJ_DIR$\..\Hardware\Inc</state>
+                    <state>$PROJ_DIR$\..\..\..\components\connectivity\at_frame</state>
+                    <state>$PROJ_DIR$\..\..\..\drivers\wifi</state>
+                    <state>$PROJ_DIR$\..\..\..\drivers\gprs</state>
+                    <state>$PROJ_DIR$\..\..\..\drivers\nb</state>
                 </option>
                 <option>
                     <name>CCStdIncCheck</name>
@@ -2083,6 +2087,18 @@
         </file>
     </group>
     <group>
+        <name>at_framework</name>
+        <file>
+            <name>$PROJ_DIR$\..\..\..\components\connectivity\at_frame\at_api_interface.c</name>
+        </file>
+        <file>
+            <name>$PROJ_DIR$\..\..\..\components\connectivity\at_frame\at_hal.c</name>
+        </file>
+        <file>
+            <name>$PROJ_DIR$\..\..\..\components\connectivity\at_frame\atadapter.c</name>
+        </file>
+    </group>
+    <group>
         <name>atiny_tiny</name>
         <file>
             <name>$PROJ_DIR$\..\..\..\components\connectivity\agent_tiny\lwm2m_client\agenttiny.c</name>
@@ -2725,6 +2741,18 @@
         </file>
         <file>
             <name>$PROJ_DIR$\..\Src\usart.c</name>
+        </file>
+    </group>
+    <group>
+        <name>user_drivers</name>
+        <file>
+            <name>$PROJ_DIR$\..\..\..\drivers\devices\nb\bc95.c</name>
+        </file>
+        <file>
+            <name>$PROJ_DIR$\..\..\..\drivers\devices\wifi\esp8266.c</name>
+        </file>
+        <file>
+            <name>$PROJ_DIR$\..\..\..\drivers\devices\gprs\sim900a.c</name>
         </file>
     </group>
 </project>

--- a/targets/STM32F429IGTx_FIRE/EWARM/Huawei_LiteOS.eww
+++ b/targets/STM32F429IGTx_FIRE/EWARM/Huawei_LiteOS.eww
@@ -3,31 +3,5 @@
     <project>
         <path>$WS_DIR$\Huawei_LiteOS.ewp</path>
     </project>
-    <batchBuild>
-        <batchDefinition>
-            <name>all</name>
-            <member>
-                <project>gpio_led_output</project>
-                <configuration>Release</configuration>
-            </member>
-            <member>
-                <project>gpio_led_output</project>
-                <configuration>Debug</configuration>
-            </member>
-        </batchDefinition>
-        <batchDefinition>
-            <name>Release</name>
-            <member>
-                <project>gpio_led_output</project>
-                <configuration>Release</configuration>
-            </member>
-        </batchDefinition>
-        <batchDefinition>
-            <name>Debug</name>
-            <member>
-                <project>gpio_led_output</project>
-                <configuration>Debug</configuration>
-            </member>
-        </batchDefinition>
-    </batchBuild>
+    <batchBuild />
 </workspace>

--- a/targets/STM32F429IGTx_FIRE/GCC/Makefile
+++ b/targets/STM32F429IGTx_FIRE/GCC/Makefile
@@ -18,6 +18,14 @@ DEBUG = 1
 # optimization
 OPT = -Og
 
+#######################################
+# network
+#######################################
+USE_AT_FRAMEWORK := no
+ifeq ($(USE_AT_FRAMEWORK), yes)
+#ESP8266   # SIM900A  # NB_NEUL95
+	NETWORK_TYPE := ESP8266
+endif
 
 #######################################
 # binaries
@@ -148,16 +156,20 @@ USER_SRC =  \
         $(TOP_DIR)/targets/STM32F429IGTx_FIRE/Src/sys_init.c
         C_SOURCES += $(USER_SRC)
 
+ifeq ($(USE_AT_FRAMEWORK), yes)
 ATADAPTOR_SRC = \
-        ${wildcard $(TOP_DIR)/components/connectivity/at_frame/*.c}
-        C_SOURCES += $(ATADAPTOR_SRC)
+    ${wildcard $(TOP_DIR)/components/connectivity/at_frame/*.c}
+    C_SOURCES += $(ATADAPTOR_SRC)
 
-USER_DRIVERS_SRC = \
-        ${wildcard $(TOP_DIR)/drivers/devices/wifi/*.c} \
-		${wildcard $(TOP_DIR)/drivers/devices/nb/*.c} \
-        ${wildcard $(TOP_DIR)/drivers/devices/gprs/*.c}
-        C_SOURCES += $(USER_DRIVERS_SRC)
-
+ifeq ($(NETWORK_TYPE), ESP8266)
+    USER_DRIVERS_SRC = ${wildcard $(TOP_DIR)/drivers/devices/wifi/*.c}
+else ifeq ($(NETWORK_TYPE), SIM900A)
+    USER_DRIVERS_SRC = ${wildcard $(TOP_DIR)/drivers/devices/gprs/*.c}
+else ifeq ($(NETWORK_TYPE), NB_NEUL95)
+    USER_DRIVERS_SRC = ${wildcard $(TOP_DIR)/drivers/devices/nb/*.c}
+endif
+    C_SOURCES += $(USER_DRIVERS_SRC)
+endif
 
 # ASM sources
 ASM_SOURCES =  \
@@ -193,7 +205,6 @@ C_DEFS =  \
         -D STM32F429xx \
         -D USE_MBED_TLS \
         -D MBEDTLS_CONFIG_FILE=\"los_mbedtls_config.h\" \
-        -D WITH_LWIP \
         -D LWM2M_LITTLE_ENDIAN \
         -D LWM2M_CLIENT_MODE \
         -D NDEBUG \
@@ -202,7 +213,11 @@ C_DEFS =  \
 #       -D WITH_DTLS \   
 #       WITH_DTLS change the place with LWIP_TIMEVAL_PRIVATE
         
-
+ifeq ($(USE_AT_FRAMEWORK), yes)
+        C_DEFS += -DWITH_AT_FRAMEWORK -DUSE_$(NETWORK_TYPE)
+else
+        C_DEFS += -D WITH_LWIP
+endif
 
 # AS includes
 AS_INCLUDES =
@@ -286,11 +301,16 @@ ATADAPTOR_INC = \
         -I $(TOP_DIR)/components/connectivity/at_frame
         C_INCLUDES += $(ATADAPTOR_INC)
 
-USER_DRIVERS_INC = \
-        -I $(TOP_DIR)/drivers/devices/wifi \
-        -I $(TOP_DIR)/drivers/devices/gprs \
-        C_INCLUDES += $(USER_DRIVERS_INC)
-
+ifeq ($(USE_AT_FRAMEWORK), yes)
+ifeq ($(NETWORK_TYPE), ESP8266)
+    USER_DRIVERS_INC = -I $(TOP_DIR)/drivers/devices/wifi
+else ifeq ($(NETWORK_TYPE), SIM900A)
+    USER_DRIVERS_INC = -I $(TOP_DIR)/drivers/devices/gprs
+else ifeq ($(NETWORK_TYPE), NB_NEUL95)
+    USER_DRIVERS_INC = -I $(TOP_DIR)/drivers/devices/nb
+endif
+    C_INCLUDES += $(USER_DRIVERS_INC)
+endif
 # compile gcc flags
 ASFLAGS = $(MCU) $(AS_DEFS) $(AS_INCLUDES) $(OPT) -Wall -fdata-sections -ffunction-sections
 


### PR DESCRIPTION
   to use at_framework, define USE_AT_FRAMEWORK = yes, and define NETWORK_TYPE to the target network type, like ESP8266,SIM900A,NB_NEUL95, etc.
2. add at_framework to iar compile project
   default using ethernet in iar project, to use at_framework, replace MACRO WITH_LWIP with WITH_AT_FRAMEWORK, and add target network type define, like USE_ESP8266,USE_SIM900A,USE_NB_NEUL95, etc.
3. change magic num in at_init_oob and Macro Define(OOB_MAX_NUM).