### PR TITLE
newlib adapting, malloc adapting and added VFS

### DIFF
--- a/fs/devfs/los_devfs.c
+++ b/fs/devfs/los_devfs.c
@@ -1,0 +1,90 @@
+/*----------------------------------------------------------------------------
+ * Copyright (c) <2013-2018>, <Huawei Technologies Co., Ltd>
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific prior written
+ * permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------
+ * Notice of Export Control Law
+ * ===============================================
+ * Huawei LiteOS may be subject to applicable export control laws and regulations, which might
+ * include those applicable to Huawei LiteOS of U.S. and the country in which you are located.
+ * Import, export and usage of Huawei LiteOS in any manner by you shall be in compliance with such
+ * applicable export control laws and regulations.
+ *---------------------------------------------------------------------------*/
+
+#include <los_config.h>
+#include <los_devfs.h>
+
+#if (LOSCFG_ENABLE_DEVFS == YES)
+
+static void * devfs_root = NULL;
+
+UINT32 los_devfs_init (void)
+{
+    if (devfs_root != NULL)
+    {
+        return LOS_OK;
+    }
+
+    if (los_kifs_init () != LOS_OK)
+    {
+        return LOS_NOK;
+    }
+
+    devfs_root = los_kifs_mount ("/dev/");
+
+    return (devfs_root == NULL) ? LOS_NOK : LOS_OK;
+}
+
+UINT32 los_devfs_create (const char * name, uint32_t flags,
+                         struct devfs_ops * devops, void * arg)
+{
+    int ret;
+
+    if (devfs_root == NULL)
+    {
+        return LOS_NOK;
+    }
+
+    ret = los_kifs_create (devfs_root, name, flags, &devops->kiops, arg);
+
+    return ret == 0 ? LOS_OK : LOS_NOK;
+}
+
+UINT32 los_devfs_link (const char * path_in_mp, uint32_t flags,
+                       void * buff, size_t size)
+{
+    int ret;
+
+    if (devfs_root == NULL)
+    {
+        return LOS_NOK;
+    }
+
+    ret = los_kifs_link (devfs_root, path_in_mp, flags, buff, size);
+
+    return ret == 0 ? LOS_OK : LOS_NOK;
+}
+
+#endif
+

--- a/fs/include/los_devfs.h
+++ b/fs/include/los_devfs.h
@@ -1,0 +1,56 @@
+/*----------------------------------------------------------------------------
+ * Copyright (c) <2013-2018>, <Huawei Technologies Co., Ltd>
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific prior written
+ * permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------
+ * Notice of Export Control Law
+ * ===============================================
+ * Huawei LiteOS may be subject to applicable export control laws and regulations, which might
+ * include those applicable to Huawei LiteOS of U.S. and the country in which you are located.
+ * Import, export and usage of Huawei LiteOS in any manner by you shall be in compliance with such
+ * applicable export control laws and regulations.
+ *---------------------------------------------------------------------------*/
+
+#ifndef _LOS_DEVFS_H
+#define _LOS_DEVFS_H
+
+#include <los_kifs.h>
+
+#define DEVFS_FLAGS_R            KIFS_ATTR_R
+#define DEVFS_FLAGS_W            KIFS_ATTR_W
+
+struct devfs_ops
+{
+    struct kifs_ops kiops;
+};
+
+extern UINT32 los_devfs_init (void);
+
+extern UINT32 los_devfs_create (const char * name, uint32_t flags,
+    struct devfs_ops * devops, void * arg);
+
+extern UINT32 los_devfs_link (const char * path_in_mp, uint32_t flags,
+    void * buff, size_t size);
+
+#endif

--- a/fs/include/los_kifs.h
+++ b/fs/include/los_kifs.h
@@ -1,0 +1,61 @@
+/*----------------------------------------------------------------------------
+ * Copyright (c) <2013-2018>, <Huawei Technologies Co., Ltd>
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific prior written
+ * permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------
+ * Notice of Export Control Law
+ * ===============================================
+ * Huawei LiteOS may be subject to applicable export control laws and regulations, which might
+ * include those applicable to Huawei LiteOS of U.S. and the country in which you are located.
+ * Import, export and usage of Huawei LiteOS in any manner by you shall be in compliance with such
+ * applicable export control laws and regulations.
+ *---------------------------------------------------------------------------*/
+
+#ifndef _LOS_KIFS_H
+#define _LOS_KIFS_H
+
+#include <los_vfs.h>
+
+#define KIFS_ATTR_R             (1 << 0)
+#define KIFS_ATTR_W             (1 << 1)
+#define KIFS_ATTR_D             (1 << 2)
+#define KIFS_ATTR_B             (1 << 3)
+
+struct kifs_ops
+{
+    int     (* open)     (void *, int);
+    int     (* close)    (void *);
+    ssize_t (* read)     (void *, char *, size_t);
+    ssize_t (* write)    (void *, const char *, size_t);
+    int     (* ioctl)    (void *, int, unsigned long);
+};
+
+extern int    los_kifs_create (void * root, const char * path_in_mp,
+    uint32_t flags, struct kifs_ops * kiops, void * arg);
+extern int    los_kifs_link (void * root, const char * path_in_mp,
+    uint32_t flags, void * buff, size_t size);
+extern void * los_kifs_mount (const char * path);
+extern int    los_kifs_init (void);
+
+#endif

--- a/fs/include/los_ramfs.h
+++ b/fs/include/los_ramfs.h
@@ -1,0 +1,40 @@
+/*----------------------------------------------------------------------------
+ * Copyright (c) <2013-2018>, <Huawei Technologies Co., Ltd>
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific prior written
+ * permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------
+ * Notice of Export Control Law
+ * ===============================================
+ * Huawei LiteOS may be subject to applicable export control laws and regulations, which might
+ * include those applicable to Huawei LiteOS of U.S. and the country in which you are located.
+ * Import, export and usage of Huawei LiteOS in any manner by you shall be in compliance with such
+ * applicable export control laws and regulations.
+ *---------------------------------------------------------------------------*/
+
+#ifndef _LOS_RAMFS_H
+#define _LOS_RAMFS_H
+
+int ramfs_init (void);
+
+#endif

--- a/fs/include/los_spiffs.h
+++ b/fs/include/los_spiffs.h
@@ -1,0 +1,50 @@
+/*----------------------------------------------------------------------------
+ * Copyright (c) <2013-2018>, <Huawei Technologies Co., Ltd>
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific prior written
+ * permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------
+ * Notice of Export Control Law
+ * ===============================================
+ * Huawei LiteOS may be subject to applicable export control laws and regulations, which might
+ * include those applicable to Huawei LiteOS of U.S. and the country in which you are located.
+ * Import, export and usage of Huawei LiteOS in any manner by you shall be in compliance with such
+ * applicable export control laws and regulations.
+ *---------------------------------------------------------------------------*/
+
+#ifndef _LOS_SPIFFS_H
+#define _LOS_SPIFFS_H
+
+#include <spiffs_config.h>
+#include <spiffs.h>
+
+extern int spiffs_init (void);
+int spiffs_mount (const char * path, u32_t phys_addr, u32_t phys_size,
+                  u32_t phys_erase_block, u32_t log_block_size,
+                  u32_t log_page_size,
+                  s32_t (*spi_rd) (struct spiffs_t *, u32_t, u32_t, u8_t *),
+                  s32_t (*spi_wr) (struct spiffs_t *, u32_t, u32_t, u8_t *),
+                  s32_t (*spi_er) (struct spiffs_t *, u32_t, u32_t));
+
+#endif
+

--- a/fs/include/los_vfs.h
+++ b/fs/include/los_vfs.h
@@ -1,0 +1,154 @@
+/*----------------------------------------------------------------------------
+ * Copyright (c) <2013-2018>, <Huawei Technologies Co., Ltd>
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific prior written
+ * permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------
+ * Notice of Export Control Law
+ * ===============================================
+ * Huawei LiteOS may be subject to applicable export control laws and regulations, which might
+ * include those applicable to Huawei LiteOS of U.S. and the country in which you are located.
+ * Import, export and usage of Huawei LiteOS in any manner by you shall be in compliance with such
+ * applicable export control laws and regulations.
+ *---------------------------------------------------------------------------*/
+
+#ifndef _LOS_VFS_H
+#define _LOS_VFS_H
+
+#include <stdio.h>
+#include <stdint.h>
+#include <los_typedef.h>
+#include <sys/stat.h>
+
+#define LOS_MAX_FILE_NAME_LEN               16
+#define LOS_FS_MAX_NAME_LEN                 LOS_MAX_FILE_NAME_LEN
+#define LOS_MAX_FILES                       8
+
+struct file;
+struct mount_point;
+struct dir;
+struct dirent;
+
+#ifdef __CC_ARM
+typedef int                                 ssize_t;
+typedef long                                off_t;
+#endif
+
+#ifdef __GNUC__
+#define VFS_ERRNO_SET(err)                  (errno = (-err))
+#else
+#define VFS_ERRNO_SET(err)
+#endif
+
+struct file_ops
+{
+    int     (*open)     (struct file *, const char *, int);
+    int     (*close)    (struct file *);
+    ssize_t (*read)     (struct file *, char *, size_t);
+    ssize_t (*write)    (struct file *, const char *, size_t);
+    off_t   (*lseek)    (struct file *, off_t, int);
+    int     (*stat)     (struct file *, struct stat *);
+    int     (*unlink)   (struct mount_point *, const char *);
+    int     (*rename)   (struct mount_point *, const char *, const char *);
+    int     (*ioctl)    (struct file *, int, unsigned long);
+    int     (*sync)     (struct file *);
+    int     (*opendir)  (struct dir *, const char *);
+    int     (*readdir)  (struct dir *, struct dirent *);
+    int     (*closedir) (struct dir *);
+    int     (*mkdir)    (struct mount_point *, const char *);
+};
+
+struct file_system
+{
+    const char            fs_name [LOS_FS_MAX_NAME_LEN];
+    struct file_ops     * fs_fops;
+    struct file_system  * fs_next;
+    volatile uint32_t     fs_refs;
+};
+
+struct mount_point
+{
+    struct file_system  * m_fs;
+    struct mount_point  * m_next;
+    const char          * m_path;
+    volatile uint32_t     m_refs;
+    UINT32                m_mutex;
+    void                * m_data;   /* used by fs private data for this mount point (like /sdb1, /sdb2), */
+};
+
+#define FILE_STATUS_NOT_USED        0
+#define FILE_STATUS_INITING         1
+#define FILE_STATUS_READY           2
+#define FILE_STATUS_CLOSING         3
+
+#define VFS_TYPE_FILE               0
+#define VFS_TYPE_DIR                1
+
+struct file
+{
+    struct file_ops    * f_fops;
+    UINT32               f_flags;
+    UINT32               f_status;
+    off_t                f_offset;
+    struct mount_point * f_mp;      /* can get private mount data here */
+    UINT32               f_owner;   /* the task that openned this file */
+    void               * f_data;
+};
+
+struct dirent
+{
+    char                 name [LOS_MAX_FILE_NAME_LEN];
+    UINT32               type;
+    UINT32               size;
+};
+
+struct dir
+{
+    struct mount_point * d_mp;      /* can get private mount data here */
+    struct dirent        d_dent;
+    off_t                d_offset;
+    void               * d_data;
+};
+
+extern int      los_open (const char *, int);
+extern int      los_close (int);
+extern ssize_t  los_read (int, char *, size_t);
+extern ssize_t  los_write (int, const void *, size_t);
+extern off_t    los_lseek (int, off_t, int);
+extern int      los_stat (const char *, struct stat *);
+extern int      los_unlink (const char *);
+extern int      los_rename (const char *, const char *);
+extern int      los_ioctl (int, int, ...);
+int             los_sync (int fd);
+struct dir    * los_opendir (const char * path);
+struct dirent * los_readdir (struct dir * dir);
+int             los_closedir (struct dir * dir);
+int             los_mkdir (const char * path, int mode);
+
+extern int      los_fs_register (struct file_system *);
+extern int      los_fs_unregister (struct file_system *);
+extern int      los_fs_mount (const char *, const char *, void *);
+extern int      los_fs_unmount (const char *);
+extern int      los_vfs_init (void);
+
+#endif

--- a/fs/include/sys/fcntl.h
+++ b/fs/include/sys/fcntl.h
@@ -1,0 +1,55 @@
+/*----------------------------------------------------------------------------
+ * Copyright (c) <2013-2018>, <Huawei Technologies Co., Ltd>
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific prior written
+ * permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------
+ * Notice of Export Control Law
+ * ===============================================
+ * Huawei LiteOS may be subject to applicable export control laws and regulations, which might
+ * include those applicable to Huawei LiteOS of U.S. and the country in which you are located.
+ * Import, export and usage of Huawei LiteOS in any manner by you shall be in compliance with such
+ * applicable export control laws and regulations.
+ *---------------------------------------------------------------------------*/
+
+#ifndef _FCNTL_H
+#define _FCNTL_H
+
+#define O_RDONLY                0
+#define O_WRONLY                1
+#define O_RDWR                  2
+#define O_APPEND                0x0008
+#define O_CREAT                 0x0200
+#define O_TRUNC                 0x0400
+#define O_EXCL                  0x0800
+#define O_SYNC                  0x2000
+#define O_NONBLOCK              0x4000
+#define O_NOCTTY                0x8000
+
+#define O_ACCMODE               (O_RDONLY | O_WRONLY | O_RDWR)
+
+//extern int open (const char *, int, ...);
+extern int open (const char * path, int flags);
+
+#endif
+

--- a/fs/include/sys/stat.h
+++ b/fs/include/sys/stat.h
@@ -1,0 +1,103 @@
+/*----------------------------------------------------------------------------
+ * Copyright (c) <2013-2018>, <Huawei Technologies Co., Ltd>
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific prior written
+ * permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------
+ * Notice of Export Control Law
+ * ===============================================
+ * Huawei LiteOS may be subject to applicable export control laws and regulations, which might
+ * include those applicable to Huawei LiteOS of U.S. and the country in which you are located.
+ * Import, export and usage of Huawei LiteOS in any manner by you shall be in compliance with such
+ * applicable export control laws and regulations.
+ *---------------------------------------------------------------------------*/
+
+#ifndef _STAT_H
+#define _STAT_H
+
+struct  stat 
+{
+  unsigned long  st_dev;
+  unsigned long  st_ino;
+  int            st_mode;
+  unsigned long  st_nlink;
+  unsigned short st_uid;
+  unsigned short st_gid;
+  unsigned long  st_rdev;
+  unsigned long  st_size;
+  unsigned long  st_atime;
+  unsigned long  st_mtime;
+  unsigned long  st_ctime;
+  unsigned long  st_blksize;
+  unsigned long  st_blocks;
+};
+
+#define _IFMT           0170000 /* type of file */
+#define _IFDIR          0040000 /* directory */
+#define _IFCHR          0020000 /* character special */
+#define _IFBLK          0060000 /* block special */
+#define _IFREG          0100000 /* regular */
+#define _IFLNK          0120000 /* symbolic link */
+#define _IFSOCK         0140000 /* socket */
+#define _IFIFO          0010000 /* fifo */
+
+#define S_BLKSIZE       1024 /* size of a block */
+
+#define S_ISUID         0004000 /* set user id on execution */
+#define S_ISGID         0002000 /* set group id on execution */
+#define S_ISVTX         0001000 /* save swapped text even after use */
+
+#define S_IFMT          _IFMT
+#define S_IFDIR         _IFDIR
+#define S_IFCHR         _IFCHR
+#define S_IFBLK         _IFBLK
+#define S_IFREG         _IFREG
+#define S_IFLNK         _IFLNK
+#define S_IFSOCK        _IFSOCK
+#define S_IFIFO         _IFIFO
+
+#define S_IRWXU         (S_IRUSR | S_IWUSR | S_IXUSR)
+#define S_IRUSR         0000400 /* read permission, owner */
+#define S_IWUSR         0000200 /* write permission, owner */
+#define S_IXUSR         0000100 /* execute/search permission, owner */
+#define S_IRWXG         (S_IRGRP | S_IWGRP | S_IXGRP)
+#define S_IRGRP         0000040 /* read permission, group */
+#define S_IWGRP         0000020 /* write permission, grougroup */
+#define S_IXGRP         0000010 /* execute/search permission, group */
+#define S_IRWXO         (S_IROTH | S_IWOTH | S_IXOTH)
+#define S_IROTH         0000004 /* read permission, other */
+#define S_IWOTH         0000002 /* write permission, other */
+#define S_IXOTH         0000001 /* execute/search permission, other */
+
+#define S_ISBLK(m)      (((m)&_IFMT) == _IFBLK)
+#define S_ISCHR(m)      (((m)&_IFMT) == _IFCHR)
+#define S_ISDIR(m)      (((m)&_IFMT) == _IFDIR)
+#define S_ISFIFO(m)     (((m)&_IFMT) == _IFIFO)
+#define S_ISREG(m)      (((m)&_IFMT) == _IFREG)
+#define S_ISLNK(m)      (((m)&_IFMT) == _IFLNK)
+#define S_ISSOCK(m)     (((m)&_IFMT) == _IFSOCK)
+
+int mkdir (const char *_path, int _mode);
+int stat (const char *__restrict __path, struct stat *__restrict __sbuf);
+
+#endif /* _STAT_H */

--- a/fs/kifs/los_kifs.c
+++ b/fs/kifs/los_kifs.c
@@ -1,0 +1,563 @@
+/*----------------------------------------------------------------------------
+ * Copyright (c) <2013-2018>, <Huawei Technologies Co., Ltd>
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific prior written
+ * permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------
+ * Notice of Export Control Law
+ * ===============================================
+ * Huawei LiteOS may be subject to applicable export control laws and regulations, which might
+ * include those applicable to Huawei LiteOS of U.S. and the country in which you are located.
+ * Import, export and usage of Huawei LiteOS in any manner by you shall be in compliance with such
+ * applicable export control laws and regulations.
+ *---------------------------------------------------------------------------*/
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#ifdef __GNUC__
+#include <sys/errno.h>
+#endif
+
+#include <los_printf.h>
+
+#include <los_vfs.h>
+#include <los_kifs.h>
+
+struct kifs_node
+{
+    char                        name [LOS_MAX_FILE_NAME_LEN];
+    uint32_t                    attr;       /* R(readable)/W(writable)/E(exclusive)/D(dir)/B(buffer) */
+    struct kifs_node          * sabling;
+    struct kifs_node          * parent;
+    union
+    {
+        struct kifs_ops       * kiops;      /* kiops if is file with ops */
+        void                  * buff;       /* buff addr, if file is linked to buffer */
+        struct kifs_node      * child;      /* child if is dir */
+    };
+    union
+    {
+        void                  * arg;        /* arg for ops if is file with ops */
+        size_t                  size;       /* buff size, if file is linked to buffer */
+    };
+};
+
+static struct kifs_node * kifs_file_find (struct kifs_node * root,
+                                          const char  * path_in_mp,
+                                          const char ** path_unresolved)
+{
+    struct kifs_node * dir = root;
+
+    while (1)
+    {
+        const char       * c;
+        struct kifs_node * t;
+        int                l;
+
+        if ((dir->attr & KIFS_ATTR_D) == 0)
+        {
+            VFS_ERRNO_SET (ENOTDIR);
+
+            return NULL;
+        }
+
+        while (*path_in_mp == '/') path_in_mp++;
+
+        c = strchr (path_in_mp, '/');
+
+        if (c == NULL)
+        {
+            l = strlen (path_in_mp);
+        }
+        else
+        {
+            l = c - path_in_mp;
+        }
+
+        if (l >= LOS_MAX_FILE_NAME_LEN)
+        {
+            VFS_ERRNO_SET (ENAMETOOLONG);
+
+            return NULL;
+        }
+
+        for (t = dir->child; t != NULL; t = t->sabling)
+        {
+            if ((strncmp (t->name, path_in_mp, l) == 0) &&
+                (t->name [l] == '\0'))
+            {
+                break;
+            }
+        }
+
+        if (t == NULL)
+        {
+            break;  /* no match */
+        }
+
+        path_in_mp += l;
+        dir        = t;
+
+        if (c == NULL)
+        {
+            break;
+        }
+    }
+
+    *path_unresolved = path_in_mp;
+
+    return dir;
+}
+
+static int kifs_open (struct file * file, const char * path_in_mp, int flags)
+{
+    struct kifs_node * node;
+
+    node = kifs_file_find ((struct kifs_node *) file->f_mp->m_data, path_in_mp,
+                           &path_in_mp);
+
+    if (node == NULL)
+    {
+        return -1;
+    }
+
+    if (*path_in_mp != '\0')
+    {
+        VFS_ERRNO_SET (ENOENT);
+        return -1;
+    }
+
+    if (node->attr & KIFS_ATTR_D)
+    {
+        VFS_ERRNO_SET (EISDIR);
+        return -1;
+    }
+
+    file->f_data = (void *) node;
+
+    if ((node->attr & KIFS_ATTR_B) != 0)
+    {
+        /* linked buffer do not have kiops */
+        return 0;
+    }
+
+    if (node->kiops->open == NULL)
+    {
+        return 0;   /* if open is NULL, means the file do not need it! */
+    }
+
+    return node->kiops->open (node->arg, flags);
+}
+
+static int kifs_close (struct file *file)
+{
+    struct kifs_node * node = (struct kifs_node *) file->f_data;
+
+    if (node == NULL)
+    {
+        return -1;
+    }
+
+    if (node->attr & KIFS_ATTR_B)
+    {
+        return 0;
+    }
+
+    if (node->kiops->close == NULL)
+    {
+        return 0;   /* if close is NULL, means the file do not need it! */
+    }
+
+    return node->kiops->close (node->arg);
+}
+
+static ssize_t kifs_read (struct file * file, char * buff, size_t bytes)
+{
+    struct kifs_node * node = (struct kifs_node *) file->f_data;
+
+    if ((node->attr & KIFS_ATTR_R) == 0)
+    {
+        VFS_ERRNO_SET (EACCES);
+        return (ssize_t) -1;
+    }
+
+    if (node->attr & KIFS_ATTR_B)
+    {
+        bytes = bytes > node->size ? node->size : bytes;
+
+        memcpy (buff, node->buff, bytes);
+
+        return bytes;
+    }
+
+    if (node->kiops->read == NULL)
+    {
+        VFS_ERRNO_SET (EACCES);
+        return (ssize_t) -1;
+    }
+
+    return node->kiops->read (node->arg, buff, bytes);
+}
+
+static ssize_t kifs_write (struct file *file, const char * buff, size_t bytes)
+{
+    struct kifs_node * node = (struct kifs_node *) file->f_data;
+
+    if ((node->attr & KIFS_ATTR_W) == 0)
+    {
+        VFS_ERRNO_SET (EACCES);
+        return (ssize_t) -1;
+    }
+
+    if (node->attr & KIFS_ATTR_B)
+    {
+        bytes = bytes > node->size ? node->size : bytes;
+
+        memcpy (node->buff, buff, bytes);
+
+        return bytes;
+    }
+
+    if (node->kiops->write == NULL)
+    {
+        VFS_ERRNO_SET (EACCES);
+        return (ssize_t) -1;
+    }
+
+    return node->kiops->write (node->arg, buff, bytes);
+}
+
+static int kifs_ioctl (struct file * file, int func, unsigned long arg)
+{
+    struct kifs_node * node = (struct kifs_node *) file->f_data;
+
+    if (node->attr & KIFS_ATTR_B)
+    {
+        return -1;
+    }
+
+    if (node->kiops->ioctl == NULL)
+    {
+        return -1;
+    }
+
+    /* <node->arg> is the private data for this kifile, the <arg> is the one
+     * of ioctl */
+
+    return node->kiops->ioctl (node->arg, func, arg);
+}
+
+static int kifs_opendir (struct dir * dir, const char * path_in_mp)
+{
+    struct kifs_node * node;
+
+    node = kifs_file_find ((struct kifs_node *) dir->d_mp->m_data, path_in_mp,
+                           &path_in_mp);
+
+    if ((node == NULL) || (*path_in_mp != '\0'))
+    {
+        VFS_ERRNO_SET (ENOENT);
+        return -1;
+    }
+
+    if ((node->attr & KIFS_ATTR_D) == 0)
+    {
+        VFS_ERRNO_SET (ENOTDIR);
+        return -1;
+    }
+
+    dir->d_data   = (void *) node;
+    dir->d_offset = 0;
+
+    return 0;
+}
+
+static int kifs_readdir (struct dir * dir, struct dirent * dent)
+{
+    struct kifs_node * node = (struct kifs_node *) dir->d_data;
+    struct kifs_node * child;
+    off_t              i;
+
+    if (node == NULL)
+    {
+        return -1;
+    }
+
+    for (i = 0, child = node->child;
+         i < dir->d_offset && child != NULL;
+         i++, child = child->sabling)
+    {
+        /* nop */
+    }
+
+    if (child == NULL)
+    {
+        VFS_ERRNO_SET (ENOENT);
+        return -1;
+    }
+
+    strncpy (dent->name, child->name, LOS_MAX_FILE_NAME_LEN - 1);
+    dent->name [LOS_MAX_FILE_NAME_LEN - 1] = '\0';
+    dent->size = 0;
+
+    if ((child->attr & KIFS_ATTR_D) != 0)
+    {
+        dent->type = VFS_TYPE_DIR;
+    }
+    else
+    {
+        dent->type = VFS_TYPE_FILE;
+        dent->size = child->size;
+    }
+
+    dir->d_offset++;
+
+    return 0;
+}
+
+static int kifs_closedir (struct dir * dir)
+{
+    return 0;
+}
+
+static struct file_ops kifs_ops =
+{
+    kifs_open,
+    kifs_close,
+    kifs_read,
+    kifs_write,
+    NULL,           /* lseek not suported */
+    NULL,           /* stat not supported */
+    NULL,           /* unlink not supported */
+    NULL,           /* rename not supported */
+    kifs_ioctl,     /* ioctl not supported */
+    NULL,           /* sync not supported */
+    kifs_opendir,
+    kifs_readdir,
+    kifs_closedir,
+    NULL            /* mkdir not supported */
+};
+
+static struct file_system kifs_fs =
+{
+    "kifs",
+    &kifs_ops,
+    NULL,
+    0
+};
+
+static struct kifs_node * kifs_file_creat (void * root,
+                                           const char * path_in_mp,
+                                           uint32_t flags)
+{
+    struct kifs_node * dir;
+    struct kifs_node * node;
+    const char       * t;
+
+    if (path_in_mp [strlen (path_in_mp) - 1] == '/')
+    {
+        return NULL;
+    }
+
+    dir = kifs_file_find ((struct kifs_node *) root, path_in_mp, &path_in_mp);
+
+    if (dir == NULL)   /* impossible */
+    {
+        return NULL;
+    }
+
+    if (*path_in_mp == '\0')
+    {
+        return NULL;
+    }
+
+    if ((dir->attr & KIFS_ATTR_D) == 0)
+    {
+        return NULL;
+    }
+
+    while ((t = strchr (path_in_mp, '/')) != NULL)
+    {
+        if ((t - path_in_mp) >= LOS_MAX_FILE_NAME_LEN)
+        {
+            return NULL;
+        }
+
+        node = (struct kifs_node *) malloc (sizeof (struct kifs_node));
+
+        if (node == NULL)
+        {
+            PRINT_ERR ("fail to malloc memory in KIFS, <malloc.c> is needed,"
+                       "make sure it is added\n");
+            return NULL;
+        }
+
+        memset (node, 0, sizeof (struct kifs_node));
+        strncpy (node->name, path_in_mp, t - path_in_mp);
+
+        node->parent  = dir;
+        node->sabling = dir->child;
+        dir->child    = node;
+        node->attr    = KIFS_ATTR_D;
+
+        dir           = node;
+        path_in_mp    = t + 1;
+
+        while (*path_in_mp == '/') path_in_mp++;
+    }
+
+    if (*path_in_mp == '\0')
+    {
+        return NULL;
+    }
+
+    node = (struct kifs_node *) malloc (sizeof (struct kifs_node));
+
+    if (node == NULL)
+    {
+        PRINT_ERR ("fail to malloc memory in KIFS, <malloc.c> is needed,"
+                   "make sure it is added\n");
+        return NULL;
+    }
+
+    memset (node, 0, sizeof (struct kifs_node));
+    strcpy (node->name, path_in_mp);
+
+    node->parent  = dir;
+    node->sabling = dir->child;
+    dir->child    = node;
+    node->attr    = flags;
+
+    return node;
+}
+
+int los_kifs_create (void * root, const char * path_in_mp, uint32_t flags,
+                     struct kifs_ops * kiops, void * arg)
+{
+    struct kifs_node * node;
+
+    if ((kiops == NULL) || ((flags & (KIFS_ATTR_R | KIFS_ATTR_W)) == 0))
+    {
+        return -1;
+    }
+
+    node = kifs_file_creat (root, path_in_mp, flags);
+
+    if (node == NULL)
+    {
+        return -1;
+    }
+
+    node->kiops = kiops;
+    node->arg   = arg;
+
+    return 0;
+}
+
+int los_kifs_link (void * root, const char * path_in_mp, uint32_t flags,
+                   void * buff, size_t size)
+{
+    struct kifs_node * node;
+
+    if ((buff == NULL) || ((flags & (KIFS_ATTR_R | KIFS_ATTR_W)) == 0))
+    {
+        return -1;
+    }
+
+    node = kifs_file_creat (root, path_in_mp, flags);
+
+    if (node == NULL)
+    {
+        return -1;
+    }
+
+    node->buff  = buff;
+    node->size  = size;
+    node->attr |= KIFS_ATTR_B;
+
+    return 0;
+}
+
+void * los_kifs_mount (const char * path)
+{
+    struct kifs_node * root;
+
+    if (los_vfs_init () != LOS_OK)
+    {
+        PRINT_ERR ("vfs init fail!\n");
+        return NULL;
+    }
+
+    if (strlen (path) >= LOS_MAX_FILE_NAME_LEN)
+    {
+        return NULL;
+    }
+
+    root = (struct kifs_node *) malloc (sizeof (struct kifs_node));
+
+    if (root == NULL)
+    {
+        PRINT_ERR ("fail to malloc memory in KIFS, <malloc.c> is needed,"
+                   "make sure it is added\n");
+        return NULL;
+    }
+
+    memset (root, 0, sizeof (struct kifs_node));
+
+    strcpy (root->name, path);
+
+    root->attr = KIFS_ATTR_D;
+
+    if (los_fs_mount ("kifs", path, root) == LOS_OK)
+    {
+        return (void *) root;
+    }
+
+    free (root);
+
+    return NULL;
+}
+
+int los_kifs_init (void)
+{
+    static int kifs_inited = FALSE;
+
+    if (kifs_inited)
+    {
+        return LOS_OK;
+    }
+
+    if (los_fs_register (&kifs_fs) != LOS_OK)
+    {
+        PRINT_ERR ("kifs fs register fail!\n");
+        return LOS_NOK;
+    }
+
+    kifs_inited = TRUE;
+
+    return LOS_OK;
+}
+

--- a/fs/ramfs/los_ramfs.c
+++ b/fs/ramfs/los_ramfs.c
@@ -1,0 +1,786 @@
+/*----------------------------------------------------------------------------
+ * Copyright (c) <2013-2018>, <Huawei Technologies Co., Ltd>
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific prior written
+ * permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------
+ * Notice of Export Control Law
+ * ===============================================
+ * Huawei LiteOS may be subject to applicable export control laws and regulations, which might
+ * include those applicable to Huawei LiteOS of U.S. and the country in which you are located.
+ * Import, export and usage of Huawei LiteOS in any manner by you shall be in compliance with such
+ * applicable export control laws and regulations.
+ *---------------------------------------------------------------------------*/
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#ifdef __GNUC__
+#include <sys/errno.h>
+#endif
+
+#if defined (__GNUC__) || defined (__CC_ARM)
+#include <sys/fcntl.h>
+#include <los_memory.h>
+#endif
+
+#include "los_vfs.h"
+
+#define RAMFS_TYPE_DIR          VFS_TYPE_DIR
+#define RAMFS_TYPE_FILE         VFS_TYPE_FILE
+
+struct ramfs_element
+{
+    char                           name [LOS_MAX_FILE_NAME_LEN];
+    uint32_t                       type;
+    struct ramfs_element         * sabling;
+    struct ramfs_element         * parent;
+    volatile uint32_t              refs;
+    union
+    {
+        struct
+        {
+            size_t                 size;
+            char                 * content;
+        } f;
+        struct
+        {
+            struct ramfs_element * child;
+        } d;
+    };
+};
+
+struct ramfs_mount_point
+{
+    struct ramfs_element       root;
+    void                     * memory;
+};
+
+static struct ramfs_element * ramfs_file_find (struct mount_point * mp,
+                                               const char  * path_in_mp,
+                                               const char ** path_unresolved)
+{
+    struct ramfs_element * walk;
+
+    /* walk every dir */
+
+    walk = &((struct ramfs_mount_point *) mp->m_data)->root;
+
+    while (1)
+    {
+        const char           * c;
+        struct ramfs_element * t;
+        int                    l;
+
+        if (walk->type != RAMFS_TYPE_DIR)
+        {
+            VFS_ERRNO_SET (ENOTDIR);
+
+            return NULL;
+        }
+
+        while (*path_in_mp == '/') path_in_mp++;
+
+        c = strchr (path_in_mp, '/');
+
+        if (c == NULL)
+        {
+            l = strlen (path_in_mp);
+        }
+        else
+        {
+            l = c - path_in_mp;
+        }
+
+        if (l >= LOS_MAX_FILE_NAME_LEN)
+        {
+            VFS_ERRNO_SET (ENAMETOOLONG);
+
+            return NULL;
+        }
+
+        for (t = walk->d.child; t != NULL; t = t->sabling)
+        {
+            if ((strncmp (t->name, path_in_mp, l) == 0) &&
+                (t->name [l] == '\0'))
+            {
+                break;
+            }
+        }
+
+        if (t == NULL)
+        {
+            break;  /* no match */
+        }
+
+        path_in_mp += l;
+        walk        = t;
+
+        if (c == NULL)
+        {
+            break;
+        }
+    }
+
+    *path_unresolved = path_in_mp;
+
+    return walk;
+}
+
+static int ramfs_open (struct file * file, const char * path_in_mp, int flags)
+{
+    struct ramfs_element * ramfs_file;
+    struct ramfs_element * walk;
+    int                    ret = -1;
+
+    /* openning dir like "/romfs/ not support " */
+
+    if (*path_in_mp == '\0')
+    {
+        VFS_ERRNO_SET (EISDIR);
+        return ret;
+    }
+
+    walk = ramfs_file_find (file->f_mp, path_in_mp, &path_in_mp);
+
+    if (walk == NULL)
+    {
+        /* errno set by ramfs_file_find */
+        return ret;
+    }
+
+    if ((walk->type == RAMFS_TYPE_DIR) && (*path_in_mp == '\0'))
+    {
+        VFS_ERRNO_SET (EISDIR);
+        return -1;
+    }
+
+    if (*path_in_mp == '\0')    /* file already exist, we found it */
+    {
+        ramfs_file = walk;
+
+        if (ramfs_file->type != RAMFS_TYPE_FILE)
+        {
+            VFS_ERRNO_SET (EISDIR);
+            return -1;
+        }
+
+        if ((flags & O_CREAT) && (flags & O_EXCL))
+        {
+            VFS_ERRNO_SET (EEXIST);
+            return -1;
+        }
+
+        if (flags & O_APPEND)
+        {
+            file->f_offset = ramfs_file->f.size;
+        }
+
+        ramfs_file->refs++;
+
+        file->f_data = (void *) ramfs_file;
+
+        return 0;
+    }
+
+    /*
+     * file not found, ramfs_file holds the most dir matched, path_in_mp holds
+     * the left path not resolved
+     */
+
+    if ((flags & O_CREAT) == 0)
+    {
+        VFS_ERRNO_SET (ENOENT);
+        return -1;
+    }
+
+    if (walk->type != RAMFS_TYPE_DIR)
+    {
+        /* if here, BUG! */
+        VFS_ERRNO_SET (ENOTDIR);
+        return -1;
+    }
+
+    if (strchr (path_in_mp, '/') != NULL)
+    {
+        VFS_ERRNO_SET (ENOENT);             /* parent dir not exist */
+        return -1;
+    }
+
+    if (strlen (path_in_mp) >= LOS_MAX_FILE_NAME_LEN)
+    {
+        VFS_ERRNO_SET (ENAMETOOLONG);
+        return -1;
+    }
+
+    ramfs_file = malloc (sizeof (struct ramfs_element));
+    if (ramfs_file == NULL)
+    {
+        PRINT_ERR ("fail to malloc memory in RAMFS, <malloc.c> is needed,"
+                   "make sure it is added\n");
+        VFS_ERRNO_SET (ENOMEM);
+        return -1;
+    }
+
+    strcpy (ramfs_file->name, path_in_mp);  /* length of path_in_mp is already verified */
+
+    ramfs_file->refs = 1;
+
+    ramfs_file->type = RAMFS_TYPE_FILE;
+    ramfs_file->sabling = walk->d.child;
+    walk->d.child = ramfs_file;
+    ramfs_file->f.content = NULL;
+    ramfs_file->f.size = 0;
+    ramfs_file->parent = walk;
+
+    file->f_data = (void *) ramfs_file;
+
+    return 0;
+}
+
+static int ramfs_close (struct file * file)
+{
+    struct ramfs_element * ramfs_file = (struct ramfs_element *) file->f_data;
+
+    ramfs_file->refs--;
+
+    return 0;           /* not file delete, do not free the content */
+}
+
+static ssize_t ramfs_read (struct file * file, char * buff, size_t bytes)
+{
+    struct ramfs_element * ramfs_file = (struct ramfs_element *) file->f_data;
+
+    if (file->f_offset < 0)
+    {
+        file->f_offset = 0;
+    }
+
+    if (ramfs_file->f.size <= (size_t) file->f_offset)  /* nothing to read */
+    {
+        return 0;
+    }
+
+    if (ramfs_file->f.size - file->f_offset < bytes)
+    {
+        bytes = ramfs_file->f.size - file->f_offset;
+    }
+
+    memcpy (buff, ramfs_file->f.content + file->f_offset, bytes);
+
+    file->f_offset += bytes;
+
+    return bytes;
+}
+
+static ssize_t ramfs_write (struct file * file, const char * buff, size_t bytes)
+{
+    struct mount_point   * mp = file->f_mp;
+    struct ramfs_element * ramfs_file = (struct ramfs_element *) file->f_data;
+
+    if (file->f_offset < 0)
+    {
+        file->f_offset = 0;
+    }
+
+    if (file->f_offset + bytes > ramfs_file->f.size)
+    {
+        char * p;
+
+        p = LOS_MemRealloc (((struct ramfs_mount_point *) mp->m_data)->memory,
+                            ramfs_file->f.content, file->f_offset + bytes);
+
+        if (p != NULL)
+        {
+            ramfs_file->f.content = p;
+            ramfs_file->f.size = file->f_offset + bytes;
+        }
+        else
+        {
+            if (ramfs_file->f.size <= (size_t) file->f_offset)
+            {
+                VFS_ERRNO_SET (ENOMEM);
+                return (ssize_t) -1;
+            }
+
+            bytes = ramfs_file->f.size - file->f_offset;
+        }
+    }
+
+    memcpy (ramfs_file->f.content + file->f_offset, buff, bytes);
+
+    file->f_offset += bytes;
+
+    return bytes;
+}
+
+static off_t ramfs_lseek (struct file * file, off_t off, int whence)
+{
+    struct ramfs_element * ramfs_file = (struct ramfs_element *) file->f_data;
+
+    switch (whence)
+    {
+        case SEEK_SET:
+            file->f_offset  = off;
+            break;
+        case SEEK_CUR:
+            file->f_offset += off;
+            break;
+        case SEEK_END:
+            file->f_offset  = ramfs_file->f.size;
+            break;
+        default:
+            VFS_ERRNO_SET (EINVAL);
+            return -1;
+    }
+
+    if (file->f_offset < 0)
+    {
+        file->f_offset = 0;
+    }
+
+    if ((size_t) file->f_offset > ramfs_file->f.size)
+    {
+        file->f_offset = ramfs_file->f.size;
+    }
+
+    return file->f_offset;
+}
+
+static void ramfs_del (struct ramfs_element * e)
+{
+    struct ramfs_element * dir;
+    struct ramfs_element * t;
+
+    if (e->parent == NULL)          /* root element, do not delete */
+    {
+        return;
+    }
+
+    dir = e->parent;
+
+    t = dir->d.child;
+
+    if (t == e)
+    {
+        dir->d.child = e->sabling;
+    }
+    else
+    {
+        while (t->sabling != e)
+        {
+            t = t->sabling;
+        }
+
+        t->sabling = e->sabling;
+    }
+
+    free (e);
+}
+
+static int ramfs_unlink (struct mount_point * mp, const char * path_in_mp)
+{
+    struct ramfs_element * ramfs_file;
+
+    ramfs_file = ramfs_file_find (mp, path_in_mp, &path_in_mp);
+
+    if ((ramfs_file == NULL) || (*path_in_mp != '\0'))
+    {
+        VFS_ERRNO_SET (ENOENT);
+        return -1;
+    }
+
+    if (ramfs_file->refs != 0)
+    {
+        VFS_ERRNO_SET (EBUSY);
+        return -1;
+    }
+
+    if (ramfs_file->type == RAMFS_TYPE_DIR)
+    {
+        if (ramfs_file->d.child != NULL)
+        {
+            VFS_ERRNO_SET (EBUSY);      /* have file under it busy */
+            return -1;
+        }
+    }
+    else
+    {
+        if (ramfs_file->f.content != NULL)
+        {
+            LOS_MemFree (((struct ramfs_mount_point *) mp->m_data)->memory,
+                         ramfs_file->f.content);
+            ramfs_file->f.content = NULL;
+        }
+    }
+
+    ramfs_del (ramfs_file);
+
+    return 0;
+}
+
+static int ramfs_rename (struct mount_point * mp, const char * path_in_mp_old,
+                         const char * path_in_mp_new)
+{
+    struct ramfs_element * ramfs_file_old;
+    struct ramfs_element * ramfs_file_new;
+
+    ramfs_file_old = ramfs_file_find (mp, path_in_mp_old, &path_in_mp_old);
+
+    if ((ramfs_file_old == NULL) || (*path_in_mp_old != '\0'))
+    {
+        VFS_ERRNO_SET (ENOENT);
+        return -1;
+    }
+
+    ramfs_file_new = ramfs_file_find (mp, path_in_mp_new, &path_in_mp_new);
+
+    /*
+     * ramfs_file_new == NULL means at least parent dir not found
+     * *path_in_mp_new == '\0' means file already exist
+     */
+
+    if ((ramfs_file_new == NULL) || (*path_in_mp_new == '\0'))
+    {
+        VFS_ERRNO_SET (ENOENT);
+        return -1;
+    }
+
+    /* must in the same dir */
+
+    if (strchr (path_in_mp_new, '/') != NULL)
+    {
+        VFS_ERRNO_SET (EISDIR);
+        return -1;
+    }
+
+    /* must in the same dir */
+
+    if (ramfs_file_new != ramfs_file_old->parent)
+    {
+        VFS_ERRNO_SET (EISDIR);
+        return -1;
+    }
+
+    if (strlen (path_in_mp_new) >= LOS_MAX_FILE_NAME_LEN)
+    {
+        VFS_ERRNO_SET (ENAMETOOLONG);
+        return -1;
+    }
+
+    strcpy (ramfs_file_old->name, path_in_mp_new);
+
+    return 0;
+}
+
+static int ramfs_opendir (struct dir * dir, const char * path_in_mp)
+{
+    struct ramfs_element * ramfs_dir;
+    struct mount_point   * mp = dir->d_mp;
+
+    ramfs_dir = ramfs_file_find (mp, path_in_mp, &path_in_mp);
+
+    if ((ramfs_dir == NULL) || (*path_in_mp != '\0'))
+    {
+        VFS_ERRNO_SET (ENOENT);
+        return -1;
+    }
+
+    if (ramfs_dir->type != RAMFS_TYPE_DIR)
+    {
+        VFS_ERRNO_SET (ENOTDIR);
+        return -1;
+    }
+
+    ramfs_dir->refs++;
+
+    dir->d_data   = (void *) ramfs_dir;
+    dir->d_offset = 0;
+
+    return 0;
+}
+
+static int ramfs_readdir (struct dir * dir, struct dirent * dent)
+{
+    struct ramfs_element * ramfs_dir = (struct ramfs_element *) dir->d_data;
+    struct ramfs_element * child;
+    off_t                  i;
+
+    for (i = 0, child = ramfs_dir->d.child;
+         i < dir->d_offset && child != NULL;
+         i++, child = child->sabling)
+    {
+        /* nop */
+    }
+
+    if (NULL == child)
+    {
+        VFS_ERRNO_SET (ENOENT);
+        return -1;
+    }
+
+    strncpy (dent->name, child->name, LOS_MAX_FILE_NAME_LEN - 1);
+    dent->name [LOS_MAX_FILE_NAME_LEN - 1] = '\0';
+    dent->size = 0;
+
+    if (child->type == RAMFS_TYPE_DIR)
+    {
+        dent->type = VFS_TYPE_DIR;
+    }
+    else
+    {
+        dent->type = VFS_TYPE_FILE;
+        dent->size = child->f.size;
+    }
+
+    dir->d_offset++;
+
+    return 0;
+}
+
+static int ramfs_closedir (struct dir * dir)
+{
+    struct ramfs_element * ramfs_dir = (struct ramfs_element *) dir->d_data;
+
+    ramfs_dir->refs--;
+
+    return 0;
+}
+
+static int ramfs_mkdir (struct mount_point * mp, const char * path_in_mp)
+{
+    struct ramfs_element * ramfs_parent;
+    struct ramfs_element * ramfs_dir;
+    const char           * t;
+    int                    len;
+
+    ramfs_parent = ramfs_file_find (mp, path_in_mp, &path_in_mp);
+
+    if ((ramfs_parent == NULL) || (*path_in_mp == '\0'))
+    {
+        return -1;      /* dir already exist */
+    }
+
+    t = strchr (path_in_mp, '/');
+
+    if (t != NULL)
+    {
+        len = t - path_in_mp;
+
+        while (*t == '/') t++;
+
+        if (*t != '\0')
+        {
+            return -1;  /* creating dir under non-existed dir */
+        }
+    }
+    else
+    {
+        len = strlen (path_in_mp);
+    }
+
+    if (len >= LOS_MAX_FILE_NAME_LEN)
+    {
+        return -1;
+    }
+
+    ramfs_dir = (struct ramfs_element *) malloc (sizeof (struct ramfs_element));
+
+    if (ramfs_dir == NULL)
+    {
+        PRINT_ERR ("fail to malloc memory in RAMFS, <malloc.c> is needed,"
+                   "make sure it is added\n");
+        return -1;
+    }
+
+    memset (ramfs_dir, 0, sizeof (struct ramfs_element));
+
+    strncpy (ramfs_dir->name, path_in_mp, len);
+    ramfs_dir->type       = RAMFS_TYPE_DIR;
+    ramfs_dir->sabling    = ramfs_parent->d.child;
+    ramfs_parent->d.child = ramfs_dir;
+    ramfs_dir->parent     = ramfs_parent;
+
+    return 0;
+}
+
+static struct file_ops ramfs_ops =
+{
+    ramfs_open,
+    ramfs_close,
+    ramfs_read,
+    ramfs_write,
+    ramfs_lseek,
+    NULL,           /* stat not supported */
+    ramfs_unlink,
+    ramfs_rename,
+    NULL,           /* ioctl not supported */
+    NULL,           /* sync not supported */
+    ramfs_opendir,
+    ramfs_readdir,
+    ramfs_closedir,
+    ramfs_mkdir
+};
+
+static struct file_system ramfs_fs =
+{
+    "ramfs",
+    &ramfs_ops,
+    NULL,
+    0
+};
+
+int ramfs_mount (const char * path, size_t block_size)
+{
+    struct ramfs_mount_point * rmp;
+
+    if (strlen (path) >= LOS_MAX_FILE_NAME_LEN)
+    {
+        return LOS_NOK;
+    }
+
+    rmp = (struct ramfs_mount_point *) malloc (sizeof (struct ramfs_mount_point));
+
+    if (rmp == NULL)
+    {
+        PRINT_ERR ("fail to malloc memory in RAMFS, <malloc.c> is needed,"
+                   "make sure it is added\n");
+        return LOS_NOK;
+    }
+
+    memset (rmp, 0, sizeof (struct ramfs_mount_point));
+    rmp->root.type = RAMFS_TYPE_DIR;
+    strncpy (rmp->root.name, path, LOS_MAX_FILE_NAME_LEN);
+    rmp->memory = malloc (block_size);
+
+    if (rmp->memory == NULL)
+    {
+        PRINT_ERR ("fail to malloc memory in RAMFS, <malloc.c> is needed,"
+                   "make sure it is added\n");
+        PRINT_ERR ("failed to allocate memory\n");
+        return LOS_NOK;
+    }
+
+    if (LOS_MemInit (rmp->memory, block_size) != LOS_OK)
+    {
+        PRINT_ERR ("failed to init pool\n");
+        free (rmp->memory);
+        return LOS_NOK;
+    }
+
+    if (los_fs_mount ("ramfs", path, rmp) == LOS_OK)
+    {
+        PRINT_INFO ("ramfs mount at %s done!\n", path);
+        return LOS_OK;
+    }
+
+    PRINT_ERR ("failed to register fs!\n");
+
+    free (rmp->memory);
+    free (rmp);
+
+    return LOS_NOK;
+}
+
+int ramfs_init (void)
+{
+    static int ramfs_inited = FALSE;
+
+    if (ramfs_inited)
+    {
+        return LOS_OK;
+    }
+
+    if (los_vfs_init () != LOS_OK)
+    {
+        PRINT_ERR ("vfs init fail!\n");
+        return LOS_NOK;
+    }
+
+    if (los_fs_register (&ramfs_fs) != LOS_OK)
+    {
+        PRINT_ERR ("failed to register fs!\n");
+        return LOS_NOK;
+    }
+
+    /* alloc 16KB memory as "disk" */
+
+    if (ramfs_mount ("/ramfs/", 16 * 1024) != LOS_OK)
+    {
+        PRINT_ERR ("failed to mount ramfs!\n");
+        return LOS_NOK;
+    }
+
+    PRINT_INFO ("register fs done!\n");
+
+    ramfs_inited = TRUE;
+
+    return LOS_OK;
+}
+
+#ifdef DEBUG
+void ramfs_ls (struct ramfs_element * dir, int level)
+{
+    struct ramfs_element * itr;
+    int                    i;
+
+    if (dir->type != RAMFS_TYPE_DIR)
+    {
+        return;
+    }
+
+    for (itr = dir->d.child; itr != NULL; itr = itr->sabling)
+    {
+        for (i = 0; i < level; i++)
+            PRINTK ("  ");
+
+        PRINTK ("%s%c\n", itr->name, itr->type == RAMFS_TYPE_DIR ? '/' : '\0');
+
+        if (itr->type == RAMFS_TYPE_DIR)
+        {
+            ramfs_ls (itr, level + 1);
+        }
+    }
+}
+
+extern struct mount_point * los_mp_find (const char *, const char **);
+
+void ramfs_tree (const char * mount_path)
+{
+    struct mount_point   * mp = los_mp_find (mount_path, NULL);
+    struct ramfs_element * walk;
+
+    if (mp == NULL)
+    {
+        PRINT_ERR ("can not find mount point info for %s\n", mount_path);
+        return;
+    }
+
+    walk = (struct ramfs_element *) mp->m_data;
+
+    ramfs_ls (walk, 0);
+}
+#endif
+

--- a/fs/spiffs/README
+++ b/fs/spiffs/README
@@ -1,0 +1,21 @@
+spiffs使用方法
+
+1）clone spiffs的代码目前没有包含在LiteOS中，所以需要从spiffs的github仓库中clone下来。spiffs的地址是：https://github.com/pellepl/spiffs.git，将spiffs的代码clone到LiteOS/fs/spiffs/spiffs_git目录下。
+
+2）进入新clone的目录，拷贝"src/test/params_test.h"到"src/default/los_spiffs_config.h"
+3）编辑"src/default/los_spiffs_config.h"：
+   3.1 在文件开头添加 "#include "los_vfs.h"
+   3.2 将"#define ASSERT(c, m)"定义成空
+   3.3 增加定义"#define SPIFFS_OBJ_NAME_LEN             LOS_MAX_FILE_NAME_LEN"
+   3.4 增加定义"#define NO_TEST"
+4）编辑"src/default/spiffs_config.h"
+   4.1 "#include "params_test.h"改为"#include "los_spiffs_config.h""
+   4.2 "#include <unistd.h>"改为：
+   
+   #ifdef __GNUC__
+   #include <unistd.h>
+   #endif
+5）编辑"src/spiffs_nucleus.h"，spiffs_page_object_ix_header结构体中，"spiffs_obj_type type;"后，"u8_t name[SPIFFS_OBJ_NAME_LEN];"前添加"u8_t _align1[4 - ((sizeof(spiffs_obj_type)&3)==0 ? 4 : (sizeof(spiffs_obj_type)&3))];"，否则会出非对齐访问，从而引发异常。
+
+6）编译工程时将"fs\spiffs\spiffs_git\src"以及"fs\spiffs\spiffs_git\src\default"加入到"include path"
+7）添加los_spiffs.c（适配spiffs的demo），然后使用"spiffs_init"初始化，以及"spiffs_mount"挂载

--- a/fs/spiffs/los_spiffs.c
+++ b/fs/spiffs/los_spiffs.c
@@ -1,0 +1,369 @@
+/*----------------------------------------------------------------------------
+ * Copyright (c) <2013-2018>, <Huawei Technologies Co., Ltd>
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific prior written
+ * permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------
+ * Notice of Export Control Law
+ * ===============================================
+ * Huawei LiteOS may be subject to applicable export control laws and regulations, which might
+ * include those applicable to Huawei LiteOS of U.S. and the country in which you are located.
+ * Import, export and usage of Huawei LiteOS in any manner by you shall be in compliance with such
+ * applicable export control laws and regulations.
+ *---------------------------------------------------------------------------*/
+
+/* NOTE: this is a demo for adapting the SPIFFS */
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <los_vfs.h>
+
+#if defined (__GNUC__) || defined (__CC_ARM)
+#include <sys/fcntl.h>
+#endif
+
+#ifdef __GNUC__
+#include <sys/unistd.h>
+#endif
+
+#include <los_printf.h>
+
+#include "spiffs.h"
+#include "spiffs_nucleus.h"
+
+static int spiffs_flags_get (int oflags)
+{
+    int flags = 0;
+
+    switch (oflags & O_ACCMODE)
+    {
+    case O_RDONLY:
+        flags |= SPIFFS_O_RDONLY;
+        break;
+    case O_WRONLY:
+        flags |= SPIFFS_O_WRONLY;
+        break;
+    case O_RDWR:
+        flags |= SPIFFS_O_RDWR;
+        break;
+    default:
+        break;
+    }
+
+    if (oflags & O_CREAT)
+    {
+        flags |= SPIFFS_O_CREAT;
+    }
+
+    if (oflags & O_EXCL)
+    {
+        flags |= SPIFFS_O_EXCL;
+    }
+
+    if (oflags & O_TRUNC)
+    {
+        flags |= SPIFFS_O_TRUNC;
+    }
+
+    if (oflags & O_APPEND)
+    {
+        flags |= SPIFFS_O_CREAT | SPIFFS_O_APPEND;
+    }
+
+    return flags;
+}
+
+static int spiffs_op_open (struct file * file, const char * path_in_mp, int flags)
+{
+    spiffs             * fs = (spiffs *) file->f_mp->m_data;
+    spiffs_file          s_file;
+
+    s_file = SPIFFS_open (fs, path_in_mp, spiffs_flags_get (flags), 0);
+
+    if (s_file < SPIFFS_OK)
+    {
+        return -1;
+    }
+
+    file->f_data = (void *) (uintptr_t) s_file;
+
+    return 0;
+}
+
+static spiffs_file spiffs_from_file (struct file * file)
+{
+    return (spiffs_file) (uintptr_t) file->f_data;
+}
+
+static int spiffs_op_close (struct file *file)
+{
+    spiffs_file  s_file = spiffs_from_file (file);
+    spiffs     * fs     = (spiffs *) file->f_mp->m_data;
+
+    return (SPIFFS_close (fs, s_file) == SPIFFS_OK) ? LOS_OK : LOS_NOK;
+}
+
+static ssize_t spiffs_op_read (struct file *file, char * buff, size_t bytes)
+{
+    spiffs_file  s_file = spiffs_from_file (file);
+    spiffs     * fs     = (spiffs *) file->f_mp->m_data;
+
+    return SPIFFS_read (fs, s_file, buff, bytes);
+}
+
+static ssize_t spiffs_op_write (struct file *file, const char * buff, size_t bytes)
+{
+    spiffs_file  s_file = spiffs_from_file (file);
+    spiffs     * fs     = (spiffs *) file->f_mp->m_data;
+
+    return SPIFFS_write (fs, s_file, (void *) buff, bytes);
+}
+
+static off_t spiffs_op_lseek (struct file * file, off_t off, int whence)
+{
+    spiffs_file  s_file = spiffs_from_file (file);
+    spiffs     * fs     = (spiffs *) file->f_mp->m_data;
+
+    return SPIFFS_lseek (fs, s_file, off, whence);
+}
+
+static int spiffs_op_unlink (struct mount_point * mp, const char * path_in_mp)
+{
+    return SPIFFS_remove ((spiffs *) mp->m_data, path_in_mp);
+}
+
+static int spiffs_op_rename (struct mount_point * mp, const char * path_in_mp_old,
+                          const char * path_in_mp_new)
+{
+    return SPIFFS_rename ((spiffs *) mp->m_data, path_in_mp_old, path_in_mp_new);
+}
+
+static int spiffs_op_sync (struct file * file)
+{
+    spiffs_file  s_file = spiffs_from_file (file);
+    spiffs     * fs     = (spiffs *) file->f_mp->m_data;
+
+    return SPIFFS_fflush (fs, s_file);
+}
+
+static int spiffs_op_opendir (struct dir * dir, const char * path)
+{
+    spiffs     * fs     = (spiffs *) dir->d_mp->m_data;
+    spiffs_DIR * sdir;
+
+    sdir = (spiffs_DIR *) malloc (sizeof (spiffs_DIR));
+
+    if (sdir == NULL)
+    {
+        PRINT_ERR ("fail to malloc memory in SPIFFS, <malloc.c> is needed,"
+                   "make sure it is added\n");
+        return -1;
+    }
+
+    dir->d_data   = (void *) SPIFFS_opendir (fs, path, sdir);
+    dir->d_offset = 0;
+
+    if (dir->d_data == 0)
+    {
+        free (sdir);
+        return -1;
+    }
+
+    return LOS_OK;
+}
+
+int spiffs_op_readdir (struct dir * dir, struct dirent * dent)
+{
+    struct spiffs_dirent e;
+
+    if (NULL == SPIFFS_readdir ((spiffs_DIR *) dir->d_data, &e))
+    {
+        return -1;
+    }
+
+    strncpy (dent->name, (const char *) e.name, LOS_MAX_FILE_NAME_LEN - 1);
+    dent->name [LOS_MAX_FILE_NAME_LEN - 1] = '\0';
+    dent->size = e.size;
+
+    if (e.type == SPIFFS_TYPE_DIR)
+    {
+        dent->type = VFS_TYPE_DIR;
+    }
+    else
+    {
+        dent->type = VFS_TYPE_FILE;
+    }
+
+    return LOS_OK;
+}
+
+static int spiffs_op_closedir (struct dir * dir)
+{
+    spiffs_DIR * sdir = (spiffs_DIR *) dir->d_data;
+
+    SPIFFS_closedir (sdir);
+
+    free (sdir);
+
+    return 0;
+}
+
+static struct file_ops spiffs_ops =
+{
+    spiffs_op_open,
+    spiffs_op_close,
+    spiffs_op_read,
+    spiffs_op_write,
+    spiffs_op_lseek,
+    NULL,               /* stat not supported for now */
+    spiffs_op_unlink,
+    spiffs_op_rename,
+    NULL,               /* ioctl not supported for now */
+    spiffs_op_sync,
+    spiffs_op_opendir,
+    spiffs_op_readdir,
+    spiffs_op_closedir,
+    NULL                /* spiffs do not support mkdir */
+};
+
+static struct file_system spiffs_fs =
+{
+    "spiffs",
+    &spiffs_ops,
+    NULL,
+    0
+};
+
+int spiffs_mount (const char * path, u32_t phys_addr, u32_t phys_size,
+                  u32_t phys_erase_block, u32_t log_block_size,
+                  u32_t log_page_size,
+                  s32_t (*spi_rd) (struct spiffs_t *, u32_t, u32_t, u8_t *),
+                  s32_t (*spi_wr) (struct spiffs_t *, u32_t, u32_t, u8_t *),
+                  s32_t (*spi_er) (struct spiffs_t *, u32_t, u32_t))
+{
+    spiffs        * fs;
+    spiffs_config   c;
+    u8_t          * wbuf;
+    u8_t          * fds;
+    u8_t          * cache;
+    int             ret = -1;
+
+#define LOS_SPIFFS_FD_SIZE      (sizeof (spiffs_fd) * 8)
+#define LOS_SPIFFS_CACHE_SIZE   (((log_page_size + 32) * 4) + 40)
+
+    fs    = (spiffs *) malloc (sizeof (spiffs));
+    wbuf  = (u8_t *)   malloc (log_page_size * 2);
+    fds   = (u8_t *)   malloc (LOS_SPIFFS_FD_SIZE);
+    cache = (u8_t *)   malloc (LOS_SPIFFS_CACHE_SIZE);
+
+    if ((fs == NULL) || (wbuf == NULL) || (fds == NULL) || (cache == NULL))
+    {
+        PRINT_ERR ("fail to malloc memory in SPIFFS, <malloc.c> is needed,"
+                   "make sure it is added\n");
+        goto err_free;
+    }
+
+    memset (fs, 0, sizeof (spiffs));
+
+    c.hal_read_f       = spi_rd;
+    c.hal_write_f      = spi_wr;
+    c.hal_erase_f      = spi_er;
+    c.log_block_size   = log_block_size;
+    c.log_page_size    = log_page_size;
+    c.phys_addr        = phys_addr;
+    c.phys_erase_block = phys_erase_block;
+    c.phys_size        = phys_size;
+    c.fh_ix_offset     = TEST_SPIFFS_FILEHDL_OFFSET;
+
+    ret = SPIFFS_mount (fs, &c, wbuf, fds, LOS_SPIFFS_FD_SIZE, cache,
+                        LOS_SPIFFS_CACHE_SIZE, NULL);
+
+    if (ret == SPIFFS_ERR_NOT_A_FS)
+    {
+        PRINT_INFO ("formating fs...\n");
+
+        SPIFFS_format (fs);
+
+        ret = SPIFFS_mount (fs, &c, wbuf, fds, LOS_SPIFFS_FD_SIZE, cache,
+                            LOS_SPIFFS_CACHE_SIZE, NULL);
+    }
+
+    if (ret != SPIFFS_OK)
+    {
+        PRINT_ERR ("format fail!\n");
+        goto err_unmount;
+    }
+
+    ret = los_fs_mount ("spiffs", path, fs);
+
+    if (ret == LOS_OK)
+    {
+        PRINT_INFO ("spiffs mount at %s done!\n", path);
+        return LOS_OK;
+    }
+
+    PRINT_ERR ("failed to mount!\n");
+
+err_unmount:
+    SPIFFS_unmount (fs);
+err_free:
+    if (fs == NULL)
+        free (fs);
+    if (wbuf == NULL)
+        free (wbuf);
+    if (fds == NULL)
+        free (fds);
+    if (cache == NULL)
+        free (cache);
+
+    return ret;
+}
+
+int spiffs_init (void)
+{
+    static int spiffs_inited = FALSE;
+
+    if (spiffs_inited)
+    {
+        return LOS_OK;
+    }
+
+    if (los_vfs_init () != LOS_OK)
+    {
+        return LOS_NOK;
+    }
+
+    if (los_fs_register (&spiffs_fs) != LOS_OK)
+    {
+        PRINT_ERR ("failed to register fs!\n");
+        return LOS_NOK;
+    }
+
+    spiffs_inited = TRUE;
+
+    PRINT_INFO ("register spiffs done!\n");
+
+    return LOS_OK;
+}
+

--- a/fs/vfs/los_vfs.c
+++ b/fs/vfs/los_vfs.c
@@ -1,0 +1,1145 @@
+/*----------------------------------------------------------------------------
+ * Copyright (c) <2013-2018>, <Huawei Technologies Co., Ltd>
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific prior written
+ * permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------
+ * Notice of Export Control Law
+ * ===============================================
+ * Huawei LiteOS may be subject to applicable export control laws and regulations, which might
+ * include those applicable to Huawei LiteOS of U.S. and the country in which you are located.
+ * Import, export and usage of Huawei LiteOS in any manner by you shall be in compliance with such
+ * applicable export control laws and regulations.
+ *---------------------------------------------------------------------------*/
+
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+#if defined (__GNUC__) || defined (__CC_ARM)
+#include <sys/fcntl.h>
+#include <los_mux.h>
+#endif
+
+#ifdef __GNUC__
+#include <sys/errno.h>
+#endif
+
+#include <los_config.h>
+#include <los_vfs.h>
+
+#if (LOSCFG_ENABLE_VFS == YES)
+
+struct file          files [LOS_MAX_FILES];
+UINT32               fs_mutex = LOS_ERRNO_MUX_PTR_NULL;
+struct mount_point * mount_points = NULL;
+struct file_system * file_systems = NULL;
+
+static int _file_2_fd (struct file * file)
+{
+    return file - files;
+}
+
+static struct file * _fd_2_file (int fd)
+{
+    return &files [fd];
+}
+
+static struct file * los_file_get (void)
+{
+    int i;
+
+    /* protected by fs_mutex */
+
+    for (i = 0; i < LOS_MAX_FILES; i++)
+    {
+        if (files[i].f_status == FILE_STATUS_NOT_USED)
+        {
+            files[i].f_status = FILE_STATUS_INITING;
+            return &files[i];
+        }
+    }
+
+    return NULL;
+}
+
+static void los_file_put(struct file * file)
+{
+    file->f_flags  = 0;
+    file->f_fops   = NULL;
+    file->f_data   = NULL;
+    file->f_mp     = NULL;
+    file->f_offset = 0;
+    file->f_owner  = (UINT32) -1;
+
+    file->f_status = FILE_STATUS_NOT_USED;
+}
+
+struct mount_point * los_mp_find (const char * path, const char ** path_in_mp)
+{
+    struct mount_point * mp = mount_points;
+    struct mount_point * best_mp = NULL;
+    int                  best_matches = 0;
+
+    if (path_in_mp != NULL)
+    {
+        *path_in_mp = NULL;
+    }
+
+    while (mp != NULL)
+    {
+        const char     * m_path  = mp->m_path;  /* mount point path */
+        const char     * i_path  = path;        /* input path */
+        int              matches = 0;
+        const char     * t;
+
+        do
+        {
+            while (*m_path == '/') m_path++;
+            while (*i_path == '/') i_path++;
+
+            t = strchr (m_path, '/');
+
+            if (t == NULL)
+            {
+                /*
+                 * m_path now is as follows:
+                 * 1) string like "abc"
+                 * 2) empty string "\0"
+                 * if it is empty string, means current mp matched
+                 */
+
+                t = strchr (m_path, '\0');
+
+                if (t == m_path)
+                {
+                    break;
+                }
+            }
+
+            if (strncmp (m_path, i_path, t - m_path) != 0)
+                {
+                goto next;  /* this mount point do not match, check next */
+                }
+
+            /*
+             * if m_path is "abc", i_path maybe:
+             * 1) "abc"
+             * 2) "abc/"
+             * 3) "abcd..."
+             * if it is not 1) or 2), this mp does not match, just goto next one
+             */
+
+            i_path  += (t - m_path);
+
+            if ((*i_path != '\0') && (*i_path != '/'))
+            {
+                goto next;
+            }
+
+            matches += (t - m_path);
+            m_path  += (t - m_path);
+        } while (*m_path != '\0');
+
+        if (matches > best_matches)
+        {
+            best_matches = matches;
+            best_mp      = mp;
+            while (*i_path == '/') i_path++;
+
+            if (path_in_mp != NULL)
+            {
+                *path_in_mp  = i_path;
+            }
+        }
+
+next:
+        mp = mp->m_next;
+    }
+
+    return best_mp;
+}
+
+int los_open (const char * path, int flags)
+{
+    struct file        * file = NULL;
+    int                  fd = -1;
+    const char         * path_in_mp;
+    struct mount_point * mp;
+
+    if (path == NULL)
+    {
+        VFS_ERRNO_SET (EINVAL);
+        return fd;
+    }
+
+    /* can not open dir */
+
+    if (path [strlen (path) - 1] == '/')
+    {
+        VFS_ERRNO_SET (EINVAL);
+        return fd;
+    }
+
+    /* prevent fs/mp being removed while opening */
+
+    if (LOS_OK != LOS_MuxPend (fs_mutex, LOS_WAIT_FOREVER))
+    {
+        VFS_ERRNO_SET (EAGAIN);
+        return fd;
+    }
+
+    file = los_file_get ();
+
+    if (file == NULL)
+    {
+        VFS_ERRNO_SET (ENFILE);
+        goto err_post_exit;
+    }
+
+    mp = los_mp_find (path, &path_in_mp);
+
+    if ((mp == NULL) || (*path_in_mp == '\0') ||
+        (mp->m_fs->fs_fops->open == NULL))
+    {
+        goto err_post_exit;
+    };
+
+    if (LOS_OK != LOS_MuxPend (mp->m_mutex, LOS_WAIT_FOREVER))
+    {
+        VFS_ERRNO_SET (EAGAIN);
+        goto err_post_exit;
+    }
+
+    LOS_MuxPost (fs_mutex);
+
+    file->f_flags  = flags;
+    file->f_offset = 0;
+    file->f_data   = NULL;
+    file->f_fops   = mp->m_fs->fs_fops;
+    file->f_mp     = mp;
+    file->f_owner  = LOS_CurTaskIDGet ();
+
+    if (file->f_fops->open (file, path_in_mp, flags) == 0)
+    {
+        mp->m_refs++;
+        fd = _file_2_fd (file);
+        file->f_status = FILE_STATUS_READY;     /* file now ready to use */
+    }
+    else
+    {
+        los_file_put (file);
+    }
+
+    LOS_MuxPost (mp->m_mutex);
+
+    return fd;
+
+err_post_exit:
+
+    LOS_MuxPost (fs_mutex);
+
+    if ((fd < 0) && (file != NULL))
+    {
+        los_file_put (file);
+    }
+
+    return fd;
+}
+
+/* attach to a file and then set new status */
+
+static struct file * _los_attach_file (int fd, UINT32 status)
+{
+    struct file        * file = NULL;
+
+    if ((fd < 0) || (fd >= LOS_MAX_FILES))
+    {
+        VFS_ERRNO_SET (EBADF);
+        return file;
+    }
+
+    file = _fd_2_file (fd);
+
+    /*
+     * Prevent file closed after the checking of:
+     *
+     *     if (file->f_status == FILE_STATUS_READY)
+     *
+     * Because our files are not privated to one task, it may be operated
+     * by every task.
+     * So we should take the mutex of current mount point before operating it,
+     * but for now we don't know if this file is valid (FILE_STATUS_READY), if
+     * this file is not valid, the f_mp may be incorrect. so
+     * we must check the status first, but this file may be closed/removed
+     * after the checking if the senquence is not correct.
+     *
+     * Consider the following code:
+     *
+     * los_attach_file (...)
+     * {
+     *     if (file->f_status == FILE_STATUS_READY)
+     *     {
+     *         while (LOS_MuxPend (file->f_mp->m_mutex, LOS_WAIT_FOREVER) != LOS_OK);
+     *
+     *         return file;
+     *     }
+     * }
+     *
+     * It is not safe:
+     *
+     * If current task is interrupted by an IRQ just after the checking and then
+     * a new task is swapped in and the new task just closed this file.
+     *
+     * So <fs_mutex> is acquire first and then check if it is valid: if not, just
+     * return NULL (which means fail); If yes, the mutex for current mount point
+     * is qcquired. And the close operation will also set task to
+     * FILE_STATUS_CLOSING to prevent other tasks operate on this file (and also
+     * prevent other tasks pend on the mutex of this mount point for this file).
+     * At last <fs_mutex> is released. And return the file handle (struct file *).
+     *
+     * As this logic used in almost all the operation routines, this routine is
+     * made to reduce the redundant code.
+     */
+
+    while (LOS_MuxPend (fs_mutex, LOS_WAIT_FOREVER) != LOS_OK);
+
+    if (file->f_status == FILE_STATUS_READY)
+    {
+        while (LOS_MuxPend (file->f_mp->m_mutex, LOS_WAIT_FOREVER) != LOS_OK);
+
+        if (status != FILE_STATUS_READY)
+        {
+            file->f_status = status;
+        }
+    }
+    else
+    {
+        VFS_ERRNO_SET (EBADF);
+        file = NULL;
+    }
+
+    LOS_MuxPost (fs_mutex);
+
+    return file;
+}
+
+static struct file * los_attach_file (int fd)
+{
+    return _los_attach_file (fd, FILE_STATUS_READY);
+}
+
+static struct file * los_attach_file_with_status (int fd, int status)
+{
+    return _los_attach_file (fd, status);
+}
+
+static UINT32 los_detach_file (struct file * file)
+{
+    return LOS_MuxPost (file->f_mp->m_mutex);
+}
+
+int los_close (int fd)
+{
+    struct file        * file;
+    int                  ret = -1;
+
+    file = los_attach_file_with_status (fd, FILE_STATUS_CLOSING);
+
+    if (file == NULL)
+    {
+        return ret;
+    }
+
+    if (file->f_fops->close != NULL)
+    {
+        ret = file->f_fops->close (file);
+    }
+
+    if (0 == ret)
+    {
+        file->f_mp->m_refs--;
+    }
+
+    los_detach_file (file);
+
+    los_file_put (file);
+
+    return ret;
+}
+
+ssize_t los_read (int fd, char * buff, size_t bytes)
+{
+    struct file * file;
+    ssize_t       ret = (ssize_t) -1;
+
+    file = los_attach_file (fd);
+
+    if (file == NULL)
+    {
+        return ret;
+    }
+
+    if ((file->f_flags & O_ACCMODE) == O_WRONLY)
+    {
+        VFS_ERRNO_SET (EACCES);
+    }
+    else if (file->f_fops->read != NULL)
+    {
+        ret = file->f_fops->read (file, buff, bytes);
+    }
+
+    /* else ret will be -1 */
+
+    los_detach_file (file);
+
+    return ret;
+}
+
+ssize_t los_write (int fd, const void * buff, size_t bytes)
+{
+    struct file * file;
+    ssize_t       ret = -1;
+
+    file = los_attach_file (fd);
+
+    if (file == NULL)
+    {
+        return ret;
+    }
+
+    if ((file->f_flags & O_ACCMODE) == O_RDONLY)
+    {
+        VFS_ERRNO_SET (EACCES);
+    }
+    else if (file->f_fops->write != NULL)
+    {
+        ret = file->f_fops->write (file, buff, bytes);
+    }
+
+    /* else ret will be -1 */
+
+    los_detach_file (file);
+
+    return ret;
+}
+
+off_t los_lseek (int fd, off_t off, int whence)
+{
+    struct file * file;
+    off_t         ret = -1;
+
+    file = los_attach_file (fd);
+
+    if (file == NULL)
+    {
+        return ret;
+    }
+
+    if (file->f_fops->lseek == NULL)
+    {
+        ret = file->f_offset;
+    }
+    else
+    {
+        ret = file->f_fops->lseek (file, off, whence);
+    }
+
+    los_detach_file (file);
+
+    return ret;
+}
+
+int los_stat (const char * path, struct stat * stat)
+{
+    struct file * file;
+    int           ret = -1;
+    int           fd = los_open (path, 0);
+
+    file = los_attach_file (fd);
+
+    if (file == NULL)   /* means closed by others :-(, not likely true */
+    {
+        return ret;
+    }
+
+    if (file->f_fops->stat != NULL)
+    {
+        ret = file->f_fops->stat (file, stat);
+    }
+
+    los_detach_file (file);
+
+    los_close (fd);
+
+    return ret;
+}
+
+int los_unlink (const char * path)
+{
+    struct mount_point * mp;
+    const char         * path_in_mp;
+    int                  ret = -1;
+
+    LOS_MuxPend (fs_mutex, LOS_WAIT_FOREVER);   /* prevent the file open/rename */
+
+    mp = los_mp_find (path, &path_in_mp);
+
+    if ((mp == NULL) || (*path_in_mp == '\0') ||
+        (mp->m_fs->fs_fops->unlink == NULL))
+    {
+        goto out;
+    }
+
+    ret = mp->m_fs->fs_fops->unlink (mp, path_in_mp);
+
+out:
+    LOS_MuxPost (fs_mutex);
+
+    return ret;
+}
+
+int los_rename (const char * old, const char * new)
+{
+    struct mount_point * mp_old;
+    struct mount_point * mp_new;
+    const char         * path_in_mp_old;
+    const char         * path_in_mp_new;
+    int                  ret = -1;
+
+    LOS_MuxPend (fs_mutex, LOS_WAIT_FOREVER);   /* prevent file open/unlink */
+
+    mp_old = los_mp_find (old, &path_in_mp_old);
+
+    if ((mp_old == NULL) || (*path_in_mp_old == '\0') ||
+        (mp_old->m_fs->fs_fops->unlink == NULL))
+    {
+        goto out;
+    }
+
+    mp_new = los_mp_find (new, &path_in_mp_new);
+
+    if ((mp_new == NULL) || (*path_in_mp_new == '\0') ||
+        (mp_new->m_fs->fs_fops->unlink == NULL))
+    {
+        goto out;
+    }
+
+    if (mp_old != mp_new)
+    {
+        VFS_ERRNO_SET (EXDEV);
+        goto out;
+    }
+
+    if (mp_old->m_fs->fs_fops->rename != NULL)
+    {
+        ret = mp_old->m_fs->fs_fops->rename (mp_old, path_in_mp_old,
+                                             path_in_mp_new);
+    }
+
+out:
+    LOS_MuxPost (fs_mutex);
+
+    return ret;
+}
+
+int los_ioctl (int fd, int func, ...)
+{
+    va_list       ap;
+    unsigned long arg;
+    struct file * file;
+    int           ret = -1;
+
+    va_start (ap, func);
+    arg = va_arg (ap, unsigned long);
+    va_end (ap);
+
+    file = los_attach_file (fd);
+
+    if (file == NULL)
+    {
+        return ret;
+    }
+
+    if (file->f_fops->ioctl != NULL)
+    {
+        ret = file->f_fops->ioctl (file, func, arg);
+    }
+
+    los_detach_file (file);
+
+    return ret;
+}
+
+int los_sync (int fd)
+{
+    struct file * file;
+    int           ret = -1;
+
+    file = los_attach_file (fd);
+
+    if (file == NULL)
+    {
+        return ret;
+    }
+
+    if (file->f_fops->sync != NULL)
+    {
+        ret = file->f_fops->sync (file);
+    }
+
+    los_detach_file (file);
+
+    return ret;
+}
+
+struct dir * los_opendir (const char * path)
+{
+    struct mount_point * mp;
+    const char         * path_in_mp;
+    struct dir         * dir = NULL;
+    int                  ret = -1;
+
+    dir = (struct dir *) malloc (sizeof (struct dir));
+
+    if (dir == NULL)
+    {
+        PRINT_ERR ("fail to malloc memory in VFS, <malloc.c> is needed,"
+                   "make sure it is added\n");
+        VFS_ERRNO_SET (ENOMEM);
+        return NULL;
+    }
+
+    if (LOS_OK != LOS_MuxPend (fs_mutex, LOS_WAIT_FOREVER))
+    {
+        VFS_ERRNO_SET (EAGAIN);
+        free (dir);
+        return NULL;
+    }
+
+    mp = los_mp_find (path, &path_in_mp);
+
+    if (mp == NULL)
+    {
+        VFS_ERRNO_SET (ENOENT);
+        LOS_MuxPost (fs_mutex);
+        free (dir);
+        return NULL;
+    }
+
+    ret = LOS_MuxPend (mp->m_mutex, LOS_WAIT_FOREVER);
+
+    LOS_MuxPost (fs_mutex);
+
+    if (ret != LOS_OK)
+    {
+        VFS_ERRNO_SET (EAGAIN);
+        free (dir);
+        return NULL;
+    }
+
+    if (mp->m_fs->fs_fops->opendir == NULL)
+    {
+        LOS_MuxPost (mp->m_mutex);
+        free (dir);
+        return NULL;
+    }
+
+    dir->d_mp     = mp;
+    dir->d_offset = 0;
+
+    ret = mp->m_fs->fs_fops->opendir (dir, path_in_mp);
+
+    if (ret == 0)
+    {
+        mp->m_refs++;
+    }
+    else
+    {
+        free (dir);
+        dir = NULL;
+    }
+
+    LOS_MuxPost (mp->m_mutex);
+
+    return dir;
+}
+
+struct dirent * los_readdir (struct dir * dir)
+{
+    struct mount_point * mp;
+    struct dirent      * ret = NULL;
+
+    if (dir == NULL)
+    {
+        VFS_ERRNO_SET (EINVAL);
+        return NULL;
+    }
+
+    mp = dir->d_mp;
+
+    if (LOS_OK != LOS_MuxPend (mp->m_mutex, LOS_WAIT_FOREVER))
+    {
+        VFS_ERRNO_SET (EAGAIN);
+        return NULL;
+    }
+
+    if ((dir->d_mp->m_fs->fs_fops->readdir != NULL) &&
+        (dir->d_mp->m_fs->fs_fops->readdir (dir, &dir->d_dent) == 0))
+    {
+        ret = &dir->d_dent;
+    }
+
+    LOS_MuxPost (mp->m_mutex);
+
+    return ret;
+}
+
+int los_closedir (struct dir * dir)
+{
+    struct mount_point * mp;
+    int                  ret = -1;
+
+    if (dir == NULL)
+    {
+        VFS_ERRNO_SET (EINVAL);
+        return -1;
+    }
+
+    mp = dir->d_mp;
+
+    if (LOS_OK != LOS_MuxPend (mp->m_mutex, LOS_WAIT_FOREVER))
+    {
+        VFS_ERRNO_SET (EAGAIN);
+        return -1;
+    }
+
+    if (dir->d_mp->m_fs->fs_fops->closedir != NULL)
+    {
+        ret = dir->d_mp->m_fs->fs_fops->closedir (dir);
+    }
+
+    if (ret == 0)
+    {
+        free (dir);
+        mp->m_refs--;
+    }
+
+    LOS_MuxPost (mp->m_mutex);
+
+    return ret;
+}
+
+int los_mkdir (const char * path, int mode)
+{
+    struct mount_point * mp;
+    const char         * path_in_mp;
+    int                  ret = -1;
+
+    (void) mode;
+
+    if (LOS_OK != LOS_MuxPend (fs_mutex, LOS_WAIT_FOREVER))
+    {
+        VFS_ERRNO_SET (EAGAIN);
+        return -1;
+    }
+
+    mp = los_mp_find (path, &path_in_mp);
+
+    if (mp == NULL)
+    {
+        VFS_ERRNO_SET (ENOENT);
+        LOS_MuxPost (fs_mutex);
+        return -1;
+    }
+
+    ret = LOS_MuxPend (mp->m_mutex, LOS_WAIT_FOREVER);
+
+    LOS_MuxPost (fs_mutex);
+
+    if (ret != LOS_OK)
+    {
+        VFS_ERRNO_SET (EAGAIN);
+        return -1;
+    }
+
+    if (mp->m_fs->fs_fops->mkdir != NULL)
+    {
+        ret = mp->m_fs->fs_fops->mkdir (mp, path_in_mp);
+    }
+    else
+    {
+        ret = -1;
+    }
+
+    LOS_MuxPost (mp->m_mutex);
+
+    return ret;
+}
+
+static int los_fs_name_check (const char * name)
+{
+    char ch;
+    int  len = 0;
+
+    do
+    {
+        ch = *name++;
+
+        if (ch == '\0')
+        {
+            break;
+        }
+
+        if ((('a' <= ch) && (ch <= 'z')) ||
+            (('A' <= ch) && (ch <= 'Z')) ||
+            (('0' <= ch) && (ch <= '9')) ||
+            (ch == '_')                  ||
+            (ch == '-'))
+        {
+            len++;
+
+            if (len == LOS_FS_MAX_NAME_LEN)
+            {
+                return LOS_NOK;
+            }
+
+            continue;
+        }
+
+        return LOS_NOK;
+    } while (1);
+
+    return len == 0 ? LOS_NOK : LOS_OK;
+}
+
+static struct file_system * los_fs_find (const char * name)
+{
+    struct file_system * fs;
+
+    for (fs = file_systems; fs != NULL; fs = fs->fs_next)
+    {
+        if (strncmp(fs->fs_name, name, LOS_FS_MAX_NAME_LEN) == 0)
+        {
+            break;
+        }
+    }
+
+    return fs;
+}
+
+int los_fs_register (struct file_system * fs)
+{
+    if ((fs == NULL) || (fs->fs_fops == NULL))
+    {
+        return LOS_NOK;
+    }
+
+    if (los_fs_name_check (fs->fs_name) != LOS_OK)
+    {
+        return LOS_NOK;
+    }
+
+    if (LOS_MuxPend (fs_mutex, LOS_WAIT_FOREVER) != LOS_OK)
+    {
+        return LOS_NOK;
+    }
+
+    if (los_fs_find (fs->fs_name) != NULL)
+    {
+        LOS_MuxPost (fs_mutex);
+        return LOS_NOK;
+    }
+
+    fs->fs_next = file_systems;
+    file_systems = fs;
+
+    LOS_MuxPost (fs_mutex);
+
+    return LOS_OK;
+}
+
+int los_fs_unregister (struct file_system * fs)
+{
+    struct file_system * prev;
+    int ret = LOS_OK;
+
+    if (fs == NULL)
+    {
+        return LOS_NOK;
+    }
+
+    if (LOS_MuxPend (fs_mutex, LOS_WAIT_FOREVER) != LOS_OK)
+    {
+        return LOS_NOK;
+    }
+
+    if (fs->fs_refs > 0)
+    {
+        goto out;
+    }
+
+    if (file_systems == fs)
+    {
+        file_systems = fs->fs_next;
+        goto out;
+    }
+
+    prev = file_systems;
+
+    while (prev != NULL)
+    {
+        if (prev->fs_next == fs)
+        {
+            break;
+        }
+
+        prev = prev->fs_next;
+    }
+
+    if (prev == NULL)
+    {
+        ret = LOS_NOK;
+    }
+    else
+    {
+        prev->fs_next = fs->fs_next;
+    }
+
+out:
+    LOS_MuxPost (fs_mutex);
+
+    return ret;
+}
+
+int los_fs_mount (const char * fsname, const char * path, void * data)
+{
+    struct file_system * fs;
+    struct mount_point * mp;
+    const char         * tmp;
+
+    if (path [0] == '\0' || path [0] != '/')
+    {
+        return LOS_NOK;
+    }
+
+    LOS_MuxPend (fs_mutex, LOS_WAIT_FOREVER);
+
+    fs = los_fs_find (fsname);
+
+    if (fs == NULL)
+    {
+        goto err_post_exit;
+    }
+
+    mp = los_mp_find (path, &tmp);
+
+    if ((mp != NULL) && (*tmp == '\0'))
+    {
+        goto err_post_exit;
+    }
+
+    mp = malloc (sizeof (struct mount_point));
+
+    if (mp == NULL)
+    {
+        PRINT_ERR ("fail to malloc memory in VFS, <malloc.c> is needed,"
+                   "make sure it is added\n");
+        goto err_post_exit;
+    }
+
+    memset (mp, 0, sizeof (struct mount_point));
+
+    mp->m_fs   = fs;
+    mp->m_path = path;
+    mp->m_data = data;
+    mp->m_refs = 0;
+
+    if (LOS_OK != LOS_MuxCreate (&mp->m_mutex))
+    {
+        goto err_free_exit;
+    }
+
+    mp->m_next = mount_points;
+    mount_points = mp;
+
+    fs->fs_refs++;
+
+    LOS_MuxPost (fs_mutex);
+
+    return LOS_OK;
+
+err_free_exit:
+    free (mp);
+err_post_exit:
+    LOS_MuxPost (fs_mutex);
+    return LOS_NOK;
+}
+
+int los_fs_unmount (const char * path)
+{
+    struct mount_point * mp;
+    struct mount_point * prev;
+    const char         * tmp;
+    int                  ret = LOS_NOK;
+
+    LOS_MuxPend (fs_mutex, LOS_WAIT_FOREVER);
+
+    mp = los_mp_find (path, &tmp);
+
+    if ((mp == NULL) || (*tmp != '\0') || (mp->m_refs != 0))
+    {
+        goto post_exit;
+    }
+
+    if (mount_points == mp)
+    {
+        mount_points = mp->m_next;
+    }
+    else
+    {
+        for (prev = mount_points; prev != NULL; prev = prev->m_next)
+        {
+            if (prev->m_next != mp)
+            {
+                continue;
+            }
+
+            prev->m_next = mp->m_next;
+            break;
+        }
+    }
+
+    LOS_MuxDelete (mp->m_mutex);
+
+    mp->m_fs->fs_refs--;
+
+    free (mp);
+
+    ret = LOS_OK;
+
+post_exit:
+    LOS_MuxPost (fs_mutex);
+    return ret;
+}
+
+int los_vfs_init (void)
+{
+    if (fs_mutex != LOS_ERRNO_MUX_PTR_NULL)
+    {
+        return LOS_OK;
+    }
+
+    if (LOS_MuxCreate (&fs_mutex) == LOS_OK)
+    {
+        return LOS_OK;
+    }
+
+    PRINT_ERR ("los_vfs_init fail!\n");
+
+    return LOS_NOK;
+}
+
+#ifdef __CC_ARM
+int open (const char * path, int flags)
+{
+    return los_open (path, flags);
+}
+
+int close (int fd)
+{
+    return los_close (fd);
+}
+
+ssize_t read (int fd, char * buff, size_t bytes)
+{
+    return los_read (fd, buff, bytes);
+}
+
+ssize_t write (int fd, const void * buff, size_t bytes)
+{
+    return los_write (fd, buff, bytes);
+}
+
+off_t lseek (int fd, off_t off, int whence)
+{
+    return los_lseek (fd, off, whence);
+}
+
+int stat (const char * path, struct stat * stat)
+{
+    return los_stat (path, stat);
+}
+
+int unlink (const char * path)
+{
+    return los_unlink (path);
+}
+
+int rename (const char * old, const char * new)
+{
+    return los_rename (old, new);
+}
+
+int ioctl (int fd, unsigned long func, ...)
+{
+    va_list       ap;
+    unsigned long arg;
+
+    va_start (ap, func);
+    arg = va_arg (ap, unsigned long);
+    va_end (ap);
+
+    return los_ioctl (fd, func, arg);
+}
+
+int sync (int fd)
+{
+    return los_sync (fd);
+}
+
+struct dir * opendir (const char * path)
+{
+    return los_opendir (path);
+}
+
+struct dirent * readdir (struct dir * dir)
+{
+    return los_readdir (dir);
+}
+
+int closedir (struct dir * dir)
+{
+    return los_closedir (dir);
+}
+
+int mkdir (const char * path, int mode)
+{
+    return los_mkdir (path, mode);
+}
+
+#endif
+
+#endif
+

--- a/kernel/base/core/los_task.c
+++ b/kernel/base/core/los_task.c
@@ -58,17 +58,20 @@ extern "C" {
 
 LITE_OS_SEC_BSS  LOS_TASK_CB                         *g_pstTaskCBArray;
 LITE_OS_SEC_BSS  ST_LOS_TASK                         g_stLosTask;
-LITE_OS_SEC_BSS  UINT16                                  g_usLosTaskLock;
-LITE_OS_SEC_BSS  UINT32                                  g_uwTskMaxNum;
-LITE_OS_SEC_BSS  UINT32                                  g_uwIdleTaskID;
-LITE_OS_SEC_BSS  UINT32                                  g_uwSwtmrTaskID;
-LITE_OS_SEC_BSS LOS_DL_LIST                         g_stTaskTimerList;
-LITE_OS_SEC_BSS LOS_DL_LIST                    g_stLosFreeTask;
-LITE_OS_SEC_BSS LOS_DL_LIST                    g_stTskRecyleList;
+LITE_OS_SEC_BSS  UINT16                              g_usLosTaskLock;
+LITE_OS_SEC_BSS  UINT32                              g_uwTskMaxNum;
+LITE_OS_SEC_BSS  UINT32                              g_uwIdleTaskID;
+LITE_OS_SEC_BSS  UINT32                              g_uwSwtmrTaskID;
+LITE_OS_SEC_BSS  LOS_DL_LIST                         g_stTaskTimerList;
+LITE_OS_SEC_BSS  LOS_DL_LIST                         g_stLosFreeTask;
+LITE_OS_SEC_BSS  LOS_DL_LIST                         g_stTskRecyleList;
 LITE_OS_SEC_BSS  TSK_SORTLINK_ATTRIBUTE_S            g_stTskSortLink;
 LITE_OS_SEC_BSS  BOOL                                g_bTaskScheduled;
 
 LITE_OS_SEC_DATA_INIT TSKSWITCHHOOK g_pfnTskSwitchHook = (TSKSWITCHHOOK)NULL; /*lint !e611*/
+#if (LOSCFG_LIB_LIBC_NEWLIB_REENT == YES)
+LITE_OS_SEC_DATA_INIT TSKSWITCHHOOK g_pfnTskSwitchImpurePtrHook = (TSKSWITCHHOOK)NULL; /*lint !e611*/
+#endif
 #if (LOSCFG_BASE_CORE_TSK_MONITOR == YES)
 LITE_OS_SEC_DATA_INIT TSKSWITCHHOOK g_pfnUsrTskSwitchHook = (TSKSWITCHHOOK)NULL; /*lint !e611*/
 #endif /* LOSCFG_BASE_CORE_TSK_MONITOR == YES */
@@ -536,6 +539,11 @@ LITE_OS_SEC_TEXT_INIT UINT32 osTaskInit(VOID)
 #if ((LOSCFG_PLATFORM_EXC == YES) && (LOSCFG_SAVE_EXC_INFO == YES))
     osExcRegister((EXC_INFO_TYPE)OS_EXC_TYPE_TSK, (EXC_INFO_SAVE_CALLBACK)LOS_TaskInfoGet, &g_uwTskMaxNum);
 #endif
+
+#if (LOSCFG_LIB_LIBC_NEWLIB_REENT == YES)
+    extern LITE_OS_SEC_TEXT VOID osTaskSwitchImpurePtr(VOID);
+    g_pfnTskSwitchImpurePtrHook = osTaskSwitchImpurePtr;
+#endif
     return LOS_OK;
 }
 
@@ -806,6 +814,10 @@ LITE_OS_SEC_TEXT_INIT UINT32 LOS_TaskCreateOnly(UINT32 *puwTaskID, TSK_INIT_PARA
     pstTaskCB->uwEventMask       = 0;
     pstTaskCB->pcTaskName        = pstInitParam->pcName;
     pstTaskCB->puwMsg = NULL;
+#if (LOSCFG_LIB_LIBC_NEWLIB_REENT == YES)
+    /* Initialise this task's Newlib reent structure. */
+    _REENT_INIT_PTR(&(pstTaskCB->stNewLibReent));
+#endif
 
     *puwTaskID = uwTaskID;
     return LOS_OK;
@@ -1564,8 +1576,25 @@ LITE_OS_SEC_TEXT CHAR* LOS_TaskNameGet(UINT32 uwTaskID)
     return pstTaskCB->pcTaskName;
 }
 
+#if (LOSCFG_LIB_LIBC_NEWLIB_REENT == YES)
+/*****************************************************************************
+ Function : osTaskSwitchImpurePtr
+ Description : Switch Newlib's _impure_ptr to point to the next run task.
+ Input       : None
+ Output      : None
+ Return      : None
+ *****************************************************************************/
+LITE_OS_SEC_TEXT VOID osTaskSwitchImpurePtr(VOID)
+{
+    /* Switch Newlib's _impure_ptr variable to point to the _reent
+       structure specific to next run task. */
+    _impure_ptr = &(g_stLosTask.pstNewTask->stNewLibReent);
+}
+#endif
+
 #ifdef __cplusplus
 #if __cplusplus
 }
 #endif /* __cplusplus */
 #endif /* __cplusplus */
+

--- a/kernel/base/include/los_task.ph
+++ b/kernel/base/include/los_task.ph
@@ -37,6 +37,10 @@
 
 #include "los_task.h"
 
+#if (LOSCFG_LIB_LIBC_NEWLIB_REENT == YES)
+#include <reent.h>
+#endif
+
 #ifdef __cplusplus
 #if __cplusplus
 extern "C" {
@@ -284,6 +288,9 @@ typedef struct tagTaskCB
     UINT32                      uwEventMask;                /**< Event mask                  */
     UINT32                      uwEventMode;                /**< Event mode                  */
     VOID                        *puwMsg;                    /**< Memory allocated to queues  */
+#if (LOSCFG_LIB_LIBC_NEWLIB_REENT == YES)
+    struct _reent stNewLibReent;                            /**< NewLib _reent struct        */
+#endif
 } LOS_TASK_CB;
 
 typedef struct stLosTask

--- a/kernel/include/los_config.h
+++ b/kernel/include/los_config.h
@@ -646,6 +646,61 @@ extern UINT32 g_sys_mem_addr_end;
 
 
 /*=============================================================================
+                                       LIB module configuration
+=============================================================================*/
+
+/**
+ * @ingroup los_config
+ * newlib struct _reent
+ */
+#ifndef LOSCFG_LIB_LIBC_NEWLIB_REENT
+#define LOSCFG_LIB_LIBC_NEWLIB_REENT                        NO
+#endif
+
+
+/*=============================================================================
+                                       VFS module configuration
+=============================================================================*/
+
+/**
+ * @ingroup los_config
+ * Configuration item for enabling LiteOS VFS
+ */
+#ifndef LOSCFG_ENABLE_VFS
+#define LOSCFG_ENABLE_VFS                                   NO
+#endif
+
+
+/**
+ * @ingroup los_config
+ * Configuration item for enabling LiteOS KIFS (kernel info fs)
+ */
+#ifndef LOSCFG_ENABLE_KIFS
+#define LOSCFG_ENABLE_KIFS                                  NO
+#endif
+
+
+/*=============================================================================
+                                       DEVFS module configuration
+=============================================================================*/
+
+/**
+ * @ingroup los_config
+ * Configuration item for enabling LiteOS DEVFS
+ */
+#ifndef LOSCFG_ENABLE_DEVFS
+#define LOSCFG_ENABLE_DEVFS                                 NO
+#else
+#if (LOSCFG_ENABLE_DEVFS == YES)
+#undef  LOSCFG_ENABLE_VFS
+#define LOSCFG_ENABLE_VFS                                   YES
+#undef  LOSCFG_ENABLE_KIFS
+#define LOSCFG_ENABLE_KIFS                                  YES
+#endif
+#endif
+
+
+/*=============================================================================
                                        Declaration of Huawei LiteOS module initialization functions
 =============================================================================*/
 

--- a/kernel/los_init.c
+++ b/kernel/los_init.c
@@ -54,7 +54,6 @@ LITE_OS_SEC_BSS UINT8* m_aucSysMem0;
 #if (LOSCFG_PLATFORM_EXC == YES)
 LITE_OS_SEC_BSS UINT8 m_aucTaskArray[MAX_EXC_MEM_SIZE];
 #endif
-extern UINT32 osTickInit(UINT32 uwSystemClock, UINT32 uwTickPerSecond);
 
 LITE_OS_SEC_TEXT_INIT void osEnableFPU(void)
 {
@@ -116,6 +115,12 @@ LITE_OS_SEC_TEXT_INIT UINT32 LOS_Start(VOID)
         return uwRet;
     }
 #endif
+
+#if (LOSCFG_LIB_LIBC_NEWLIB_REENT == YES)
+    extern VOID osTaskSwitchImpurePtr(VOID);
+    osTaskSwitchImpurePtr();
+#endif
+
     LOS_StartToRun();
 
     return uwRet;

--- a/lib/libc/malloc.c
+++ b/lib/libc/malloc.c
@@ -1,0 +1,299 @@
+/************************************************************************
+ * Copyright (c) <2013-2015>, <Huawei Technologies Co., Ltd>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice,this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice,this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ ************************************************************************/
+
+/************************************************************************
+ * Notice of Export Control Law
+ * ===============================================
+ * Huawei LiteOS may be subject to applicable export control laws and regulations,
+ * which might include those applicable to Huawei LiteOS of U.S. and the country
+ * in which you are located.
+ * Import, export and usage of Huawei LiteOS in any manner by you shall be in
+ * compliance with such applicable export control laws and regulations.
+ ************************************************************************/
+
+#include "stdlib.h"
+#include "los_memory.h"
+#include "string.h"
+
+#if defined(LOS_LIBC_MALLOC_ALIGN) && !defined(LOS_LIBC_MALLOC_ALIGN_SIZE)
+    #error "macro LOS_LIBC_MALLOC_ALIGN_SIZE undefined"
+#endif
+
+
+/*****************************************************************************
+Function         :      free
+Description      :      Deallocates the memory previously allocated by a call to calloc, malloc, or
+                realloc. The argument ptr points to the space that was previously allocated.
+                If ptr points to a memory block that was not allocated with calloc, malloc,
+                or realloc, or is a space that has been deallocated, then the result is
+                undefined.
+Input            :      [1] void *ptr, pointed to the memory need to free.
+Output           :      nothing.
+Return           :      No value is returned.
+*****************************************************************************/
+void free(void *ptr)
+{
+    if (ptr == NULL)
+        return;
+
+    LOS_MemFree((void *)OS_SYS_MEM_ADDR, ptr);/*lint !e534*/
+}
+
+
+/*****************************************************************************
+Function         :      malloc
+Description      :      Allocates the requested memory and returns a pointer to it. The requested
+                size is size bytes. The value of the space is indeterminate.
+Input            :      [1] size_t size, spcified the size need to allocate.
+Output           :      nothing.
+Return           :      On success a pointer to the requested space is returned.
+                On failure a null pointer is returned.
+*****************************************************************************/
+void *malloc(size_t size) /*lint !e31 !e10*/
+{
+    void *ptr = NULL; /*lint !e64 !e10*/
+
+    if (size == 0)
+        return NULL; /*lint !e64*/
+
+#if defined(LOS_LIBC_MALLOC_ALIGN)
+    ptr = LOS_MemAllocAlign((void *)OS_SYS_MEM_ADDR, (UINT32)size, LOS_LIBC_MALLOC_ALIGN_SIZE);
+#else
+    ptr = LOS_MemAlloc((void *)OS_SYS_MEM_ADDR, (UINT32)size);
+#endif
+
+    return ptr;
+}
+
+
+void *zalloc(size_t size) /*lint !e10*/
+{
+    void *ptr = malloc (size);
+
+    if (ptr != NULL)
+    {
+        memset((void *)ptr, (int)0, size);
+    }
+
+    return ptr;
+}
+
+
+/*****************************************************************************
+Function         :      calloc
+Description      :    Allocates the requested memory and returns a pointer to it. The requested
+                size is nitems each size bytes long (total memory requested is nitems*size).
+                The space is initialized to all zero bits.
+Input            :      [1] size_t nitems,
+                [2] size_t size,
+Output           :      nothing.
+Return           :      On success a pointer to the requested space is returned.
+                On failure a null pointer is returned.
+*****************************************************************************/
+void *calloc(size_t nitems, size_t size) /*lint !e578*/
+{
+    return zalloc(nitems * size);
+}
+
+
+/*****************************************************************************
+Function         :      memalign
+Description      :      allocates a block of size bytes whose address is a multiple of boundary.
+               The boundary must be a power of two!
+Input            :      [1] size_t size, spcified the size need to allocate.
+               [2] size_t boundary, the returned memory address will be a multiple of boundary.
+               This argument must be a power of two. This property is not checked by
+               memalign, so misuse may result in random runtime errors.
+Output           :      nothing.
+Return           :      On success a pointer to the requested space is returned.
+               On failure a null pointer is returned.
+*****************************************************************************/
+void * memalign (size_t boundary, size_t size) /*lint !e18 !e578*/
+{ /*lint !e18 !e578*/
+    void *ptr = NULL;
+
+    if(size == 0)
+        return NULL; /*lint !e64*/
+
+    ptr = LOS_MemAllocAlign((void *)OS_SYS_MEM_ADDR, (UINT32)size, (UINT32)boundary);
+
+    return ptr; /*lint !e64*/
+}
+
+
+/*****************************************************************************
+Function         :      realloc
+Description      :      Attempts to resize the memory block pointed to by ptr that was previously
+                allocated with a call to malloc or calloc. The contents pointed to by ptr are
+                unchanged. If the value of size is greater than the previous size of the
+                block, then the additional bytes have an undeterminate value. If the value
+                of size is less than the previous size of the block, then the difference of
+                bytes at the end of the block are freed. If ptr is null, then it behaves like
+                malloc. If ptr points to a memory block that was not allocated with calloc
+                or malloc, or is a space that has been deallocated, then the result is
+                undefined. If the new space cannot be allocated, then the contents pointed
+                to by ptr are unchanged. If size is zero, then the memory block is completely
+                freed.
+Input            :      [1] void *ptr, pointed to the memory which need to remalloc.
+                [2] size_t size, specified the size to remalloc.
+Output           :      nothing.
+Return           :      On success a pointer to the memory block is returned (which may be in a
+                different location as before).
+               On failure or if size is zero, a null pointer is returned.
+*****************************************************************************/
+void *realloc(void *ptr, size_t size)
+{
+    if (ptr == NULL)
+    {
+        return malloc(size); /*lint !e64*/
+    }
+
+    if (size == 0)
+    {
+        free(ptr);
+        return NULL;
+    }
+
+    return LOS_MemRealloc((void *)OS_SYS_MEM_ADDR, (void *)ptr, (UINT32)size);
+}
+
+
+#if OS_SYS_NOCACHEMEM_SIZE
+/*****************************************************************************
+Function       :   nocache_free
+Description      :   Deallocates the memory previously allocated by a call to calloc, malloc, or
+             realloc. The argument ptr points to the space that was previously allocated.
+             If ptr points to a memory block that was not allocated with calloc, malloc,
+             or realloc, or is a space that has been deallocated, then the result is
+             undefined.
+Input          :   [1] void *ptr, pointed to the memory need to free.
+Output          :   nothing.
+Return          :   No value is returned.
+*****************************************************************************/
+void nocache_free(void *ptr)
+{
+    if(ptr == NULL)
+        return;
+
+    LOS_MemFree((void *)OS_SYS_NOCACHEMEM_ADDR, ptr);
+}
+
+
+/*****************************************************************************
+Function       :   nocache_malloc
+Description      :   Allocates the requested memory and returns a pointer to it. The requested
+             size is size bytes. The value of the space is indeterminate.
+Input          :   [1] size_t size, spcified the size need to allocate.
+Output          :   nothing.
+Return          :   On success a pointer to the requested space is returned.
+             On failure a null pointer is returned.
+*****************************************************************************/
+void *nocache_malloc(size_t size)
+{
+    void *ptr = NULL;
+
+    if(size == 0)
+        return NULL;
+
+    ptr = LOS_MemAlloc((void *)OS_SYS_NOCACHEMEM_ADDR,  (UINT32)size);
+
+    return ptr;
+}
+
+
+void *nocache_zalloc(size_t size)
+{
+    void *ptr = nocache_malloc(size);
+
+    if (ptr != NULL)
+    {
+        memset((void *)ptr, (int)0, size);
+    }
+
+    return ptr;
+}
+
+
+/*****************************************************************************
+Function       :   nocache_calloc
+Description      :   Allocates the requested memory and returns a pointer to it. The requested
+             size is nitems each size bytes long (total memory requested is nitems*size).
+             The space is initialized to all zero bits.
+Input          :   [1] size_t nitems,
+             [2] size_t size,
+Output          :   nothing.
+Return          :   On success a pointer to the requested space is returned.
+             On failure a null pointer is returned.
+*****************************************************************************/
+void *nocache_calloc(size_t nitems, size_t size)
+{
+    return nocache_zalloc (nitems * size);
+}
+
+
+/*****************************************************************************
+Function       :   nocache_realloc
+Description      :   Attempts to resize the memory block pointed to by ptr that was previously
+             allocated with a call to malloc or calloc. The contents pointed to by ptr are
+             unchanged. If the value of size is greater than the previous size of the
+             block, then the additional bytes have an undeterminate value. If the value
+             of size is less than the previous size of the block, then the difference of
+             bytes at the end of the block are freed. If ptr is null, then it behaves like
+             malloc. If ptr points to a memory block that was not allocated with calloc
+             or malloc, or is a space that has been deallocated, then the result is
+             undefined. If the new space cannot be allocated, then the contents pointed
+             to by ptr are unchanged. If size is zero, then the memory block is completely
+             freed.
+Input          :   [1] void *ptr, pointed to the memory which need to remalloc.
+             [2] size_t size, specified the size to remalloc.
+Output          :   nothing.
+Return          :   On success a pointer to the memory block is returned (which may be in a
+             different location as before).
+             On failure or if size is zero, a null pointer is returned.
+*****************************************************************************/
+void *nocache_realloc(void *ptr, size_t size)
+{
+    if (ptr == NULL)
+    {
+        ptr = malloc(size);
+        return ptr;
+    }
+
+    if (size == 0)
+    {
+        free(ptr);
+        return NULL;
+    }
+
+    return LOS_MemRealloc((void *)OS_SYS_NOCACHEMEM_ADDR, (void *)ptr, (UINT32)size);
+}
+#endif
+
+/* EOF malloc.c */
+

--- a/lib/libc/newlib_stub.c
+++ b/lib/libc/newlib_stub.c
@@ -1,0 +1,244 @@
+/*----------------------------------------------------------------------------
+ * Copyright (c) <2013-2018>, <Huawei Technologies Co., Ltd>
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific prior written
+ * permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------
+ * Notice of Export Control Law
+ * ===============================================
+ * Huawei LiteOS may be subject to applicable export control laws and regulations, which might
+ * include those applicable to Huawei LiteOS of U.S. and the country in which you are located.
+ * Import, export and usage of Huawei LiteOS in any manner by you shall be in compliance with such
+ * applicable export control laws and regulations.
+ *---------------------------------------------------------------------------*/
+
+#include <reent.h>
+#include <stdlib.h>
+#include <sys/errno.h>
+#include <sys/unistd.h>
+#include <sys/time.h>
+#include <string.h>
+#include <sys/unistd.h>
+#include <los_memory.h>
+#include <los_vfs.h>
+#include <stdarg.h>
+
+#include "los_config.h"
+
+int _execve_r(struct _reent *ptr, const char *name, char *const *argv, char *const *env)
+{
+    /* not support */
+    ptr->_errno = ENOTSUP;
+    return -1;
+}
+
+int _fcntl_r(struct _reent *ptr, int fd, int cmd, int arg)
+{
+    /* not support */
+    ptr->_errno = ENOTSUP;
+    return -1;
+}
+
+int _fork_r(struct _reent *ptr)
+{
+    /* not support */
+    ptr->_errno = ENOTSUP;
+    return -1;
+}
+
+int _getpid_r(struct _reent *ptr)
+{
+    /* not support */
+    ptr->_errno = ENOTSUP;
+    return -1;
+}
+
+int _isatty_r(struct _reent *ptr, int fd)
+{
+    if (fd >= 0 && fd < 3)
+    {
+        return 1;
+    }
+
+    /* not support */
+    ptr->_errno = ENOTSUP;
+    return -1;
+}
+
+int _kill_r(struct _reent *ptr, int pid, int sig)
+{
+    /* not support */
+    ptr->_errno = ENOTSUP;
+    return -1;
+}
+
+int _link_r(struct _reent *ptr, const char *old, const char *new)
+{
+    /* not support */
+    ptr->_errno = ENOTSUP;
+    return -1;
+}
+
+_off_t _lseek_r(struct _reent *ptr, int fd, _off_t pos, int whence)
+{
+    return los_lseek (fd, pos, whence);
+}
+
+int closedir (struct dir * dir)
+{
+    return los_closedir (dir);
+}
+
+struct dir * opendir (const char * path)
+{
+    return los_opendir (path);
+}
+
+int mkdir (const char *path, int mode)
+{
+    return los_mkdir (path, mode);
+}
+
+int _mkdir_r(struct _reent *ptr, const char *name, int mode)
+{
+    ptr->_errno = ENOTSUP;
+    return 0;
+}
+
+int _open_r(struct _reent *ptr, const char *file, int flags, int mode)
+{
+    return los_open (file, flags);  /* mode not supported */
+}
+
+int _close_r(struct _reent *ptr, int fd)
+{
+    return los_close (fd);
+}
+
+_ssize_t _read_r(struct _reent *ptr, int fd, void *buf, size_t nbytes)
+{
+    return los_read (fd, buf, nbytes);
+}
+
+_ssize_t _write_r(struct _reent *ptr, int fd, const void *buf, size_t nbytes)
+{
+    return los_write (fd, buf, nbytes);
+}
+
+int _fstat_r(struct _reent *ptr, int fd, struct stat *pstat)
+{
+    /* not support */
+    ptr->_errno = ENOTSUP;
+    return -1;
+}
+
+int _rename_r(struct _reent *ptr, const char *old, const char *new)
+{
+    return los_rename (old, new);
+}
+
+void *_sbrk_r(struct _reent *ptr, ptrdiff_t incr)
+{
+    /* not support */
+    ptr->_errno = ENOTSUP;
+    return NULL;
+}
+
+int _stat_r(struct _reent *ptr, const char *file, struct stat *pstat)
+{
+    return los_stat (file, pstat);;
+}
+
+_CLOCK_T_ _times_r(struct _reent *ptr, struct tms *ptms)
+{
+    /* not support */
+    ptr->_errno = ENOTSUP;
+    return -1;
+}
+
+int _unlink_r(struct _reent *ptr, const char *file)
+{
+    return los_unlink (file);
+}
+
+int _wait_r(struct _reent *ptr, int *status)
+{
+    /* not support */
+    ptr->_errno = ENOTSUP;
+    return -1;
+}
+
+int _gettimeofday_r(struct _reent *ptr, struct timeval *tv, void *__tzp)
+{
+    /* not support */
+    ptr->_errno = ENOTSUP;
+    return -1;
+}
+
+void *_malloc_r(struct _reent *ptr, size_t size)
+{
+    return malloc(size);
+}
+
+void *_realloc_r(struct _reent *ptr, void *old, size_t newlen)
+{
+    return realloc (old, newlen);
+}
+
+void *_calloc_r(struct _reent *ptr, size_t size, size_t len)
+{
+    return calloc(size, len);
+}
+
+void _free_r(struct _reent *ptr, void *addr)
+{
+    free(addr);
+}
+
+void _exit(int status)
+{
+    while (1);
+}
+
+void _system(const char *s)
+{
+    return;
+}
+
+void abort(void)
+{
+    while (1);
+}
+
+int ioctl (int fd, unsigned long func, ...)
+{
+    va_list       ap;
+    unsigned long arg;
+
+    va_start (ap, func);
+    arg = va_arg (ap, unsigned long);
+    va_end (ap);
+
+    return los_ioctl (fd, func, arg);
+}
+


### PR DESCRIPTION
…ealloc, free). And the default malloc alignment can be changed by:

   1.1 define "LOS_LIBC_MALLOC_ALIGN", for example, in Makefile, add "-D LOS_LIBC_MALLOC_ALIGN"
   1.2 define "LOS_LIBC_MALLOC_ALIGN_SIZE", for example, in Makefile, add "-D LOS_LIBC_MALLOC_ALIGN_SIZE=8"
2) newlib _reent support for multi-tasking, when using GCC, define "LOSCFG_LIB_LIBC_NEWLIB_REENT" as "YES" to enable this.
   2.1 _reent is defined in the task CB
   2.2 CB->_reent is initialized when task creating
   2.3 in the task switching hook, current _reent is set
3) added VFS (note: VFS requires the malloc feature)
   3.1 connected VFS with the standard C open/close/read/write/... routines
   3.2 added ramfs demo using VFS
   3.3 adapted spiffs (spiffs code not included, refer to fs/spiffs/README for setup spiffs)
   3.4 added kifs (kernel info fs) using VFS, for potential temporary ram fs like devfs/procfs/... in furture
   3.5 added draft devfs using kifs, tested connecting an uart device and then the printf can work as "printf->write (1, ...)->vfs->kifs->devfs->uart" with GCC