### PR TITLE
msp430f5438a taurus v4.2

### DIFF
--- a/arch/msp430/include/los_hw.h
+++ b/arch/msp430/include/los_hw.h
@@ -1,0 +1,198 @@
+/*----------------------------------------------------------------------------
+ * Copyright (c) <2013-2018>, <Huawei Technologies Co., Ltd>
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific prior written
+ * permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------
+ * Notice of Export Control Law
+ * ===============================================
+ * Huawei LiteOS may be subject to applicable export control laws and regulations, which might
+ * include those applicable to Huawei LiteOS of U.S. and the country in which you are located.
+ * Import, export and usage of Huawei LiteOS in any manner by you shall be in compliance with such
+ * applicable export control laws and regulations.
+ *---------------------------------------------------------------------------*/
+
+ /**@defgroup los_hw hardware
+   *@ingroup kernel
+ */
+
+#ifndef _LOS_HW_H
+#define _LOS_HW_H
+
+#include "los_base.h"
+#ifdef __cplusplus
+#if __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+#endif /* __cplusplus */
+
+/**
+ * @ingroup los_hw
+ * The initialization value of stack space.
+ */
+#define EMPTY_STACK                 0xCACA
+
+
+/**
+ * @ingroup los_hw
+ * Check task schedule.
+ */
+#define LOS_CHECK_SCHEDULE          ((!g_usLosTaskLock))
+
+/**
+ * @ingroup los_hw
+ * Define the type of a task context control block.
+ */
+
+typedef struct tagTskContext
+{
+#if (__CODE_MODEL__ != __CODE_MODEL_LARGE__) && \
+    (__DATA_MODEL__ != __DATA_MODEL_LARGE__)
+    unsigned int  r4;
+    unsigned int  r5;
+    unsigned int  r6;
+    unsigned int  r7;
+    unsigned int  r8;
+    unsigned int  r9;
+    unsigned int  r10;
+    unsigned int  r11;
+    unsigned int  r12;
+    unsigned int  r13;
+    unsigned int  r14;
+    unsigned int  r15;
+#else
+    unsigned long r4;
+    unsigned long r5;
+    unsigned long r6;
+    unsigned long r7;
+    unsigned long r8;
+    unsigned long r9;
+    unsigned long r10;
+    unsigned long r11;
+    unsigned long r12;
+    unsigned long r13;
+    unsigned long r14;
+    unsigned long r15;
+#endif
+    unsigned int sr;
+    unsigned int pc;
+} TSK_CONTEXT_S;
+
+
+/**
+ * @ingroup  los_hw
+ * @brief: Task stack initialization.
+ *
+ * @par Description:
+ * This API is used to initialize the task stack.
+ *
+ * @attention:
+ * <ul><li>None.</li></ul>
+ *
+ * @param  uwTaskID     [IN] Type#UINT32: TaskID.
+ * @param  uwStackSize  [IN] Type#UINT32: Total size of the stack.
+ * @param  pTopStack    [IN] Type#VOID *: Top of task's stack.
+ *
+ * @retval: pstContext Type#TSK_CONTEXT_S *.
+ * @par Dependency:
+ * <ul><li>los_hw.h: the header file that contains the API declaration.</li></ul>
+ * @see None.
+ * @since Huawei LiteOS V100R001C00
+ */
+extern VOID * osTskStackInit(UINT32 uwTaskID, UINT32 uwStackSize, VOID *pTopStack);
+
+
+
+/**
+ * @ingroup  los_hw
+ * @brief: Task scheduling Function.
+ *
+ * @par Description:
+ * This API is used to scheduling task.
+ *
+ * @attention:
+ * <ul><li>None.</li></ul>
+ *
+ * @param  None.
+ *
+ * @retval: None.
+ * @par Dependency:
+ * <ul><li>los_hw.h: the header file that contains the API declaration.</li></ul>
+ * @see None.
+ * @since Huawei LiteOS V100R001C00
+ */
+extern VOID osSchedule(VOID);
+
+
+/**
+ * @ingroup  los_hw
+ * @brief: Function to determine whether task scheduling is required.
+ *
+ * @par Description:
+ * This API is used to Judge and entry task scheduling.
+ *
+ * @attention:
+ * <ul><li>None.</li></ul>
+ *
+ * @param  None.
+ *
+ * @retval: None.
+ * @par Dependency:
+ * <ul><li>los_hw.h: the header file that contains the API declaration.</li></ul>
+ * @see None.
+ * @since Huawei LiteOS V100R001C00
+ */
+extern VOID LOS_Schedule(VOID);
+
+LITE_OS_SEC_TEXT_MINOR VOID osTaskExit(VOID);
+
+/**
+ * @ingroup  los_hw
+ * @brief: Enter CPU low power mode.
+ *
+ * @par Description:
+ * This API is used to make CPU enter to power-save mode.
+ *
+ * @attention:
+ * <ul><li>None.</li></ul>
+ *
+ * @param  None.
+ *
+ * @retval: None.
+ * @par Dependency:
+ * <ul><li>los_hw.h: the header file that contains the API declaration.</li></ul>
+ * @see None.
+ * @since Huawei LiteOS V100R001C00
+ */
+
+extern VOID osEnterSleep(VOID);
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* __cplusplus */
+
+
+#endif /* _LOS_HW_H */
+

--- a/arch/msp430/include/los_hwi.h
+++ b/arch/msp430/include/los_hwi.h
@@ -1,0 +1,248 @@
+/*----------------------------------------------------------------------------
+ * Copyright (c) <2013-2018>, <Huawei Technologies Co., Ltd>
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific prior written
+ * permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------
+ * Notice of Export Control Law
+ * ===============================================
+ * Huawei LiteOS may be subject to applicable export control laws and regulations, which might
+ * include those applicable to Huawei LiteOS of U.S. and the country in which you are located.
+ * Import, export and usage of Huawei LiteOS in any manner by you shall be in compliance with such
+ * applicable export control laws and regulations.
+ *---------------------------------------------------------------------------*/
+
+ /**@defgroup los_hwi Hardware interrupt
+   *@ingroup kernel
+ */
+#ifndef _LOS_HWI_H
+#define _LOS_HWI_H
+
+#include "los_errno.h"
+#include "stdint.h"
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+#endif /* __cplusplus */
+
+/**
+ * @ingroup  los_hwi
+ * Define the type of a hardware interrupt handling function.
+ */
+
+struct hwi_int_handle
+{
+    void   (* pfn) (uintptr_t);
+    uintptr_t arg;
+};
+
+
+/**
+ * @ingroup los_hwi
+ * Count of interrupts.
+ */
+extern unsigned char g_int_cnt;
+
+/**
+ * @ingroup los_hwi
+ * An interrupt is active.
+ */
+#define OS_INT_ACTIVE               (g_int_cnt > 0)
+
+
+/**
+ * @ingroup los_hwi
+ * An interrupt is inactive.
+ */
+#define OS_INT_INACTIVE             (!(OS_INT_ACTIVE))
+
+
+/**
+ * @ingroup los_hwi
+ * Hardware interrupt error code: Invalid interrupt number.
+ *
+ * Value: 0x02000900
+ *
+ * Solution: Ensure that the interrupt number is valid. The value range of the interrupt vector is [0, RESET_VECTOR], the defination for vector numbers can be found at the SOC header file, for example: msp430f5438a.h.
+ */
+#define OS_ERRNO_HWI_NUM_INVALID                            LOS_ERRNO_OS_ERROR(LOS_MOD_HWI, 0x00)
+
+/**
+ * @ingroup los_hwi
+ * Hardware interrupt error code: Null hardware interrupt handling function.
+ *
+ * Value: 0x02000901
+ *
+ * Solution: Pass in a valid non-null hardware interrupt handling function.
+ */
+#define OS_ERRNO_HWI_PROC_FUNC_NULL                         LOS_ERRNO_OS_ERROR(LOS_MOD_HWI, 0x01)
+
+/**
+ * @ingroup los_hwi
+ * Hardware interrupt error code: The interrupt has already been created.
+ *
+ * Value: 0x02000904
+ *
+ * Solution: Check whether the interrupt specified by the passed-in interrupt number has already been created.
+ */
+#define OS_ERRNO_HWI_ALREADY_CREATED                        LOS_ERRNO_OS_ERROR(LOS_MOD_HWI, 0x04)
+
+/**
+ * @ingroup  los_hwi
+ * @brief Create a hardware interrupt.
+ *
+ * @par Description:
+ * This API is used to configure a hardware interrupt and register a hardware interrupt handling function.
+ *
+ * @attention
+ * <ul>
+ * <li>Hardware interrupt vector number value range: [0, RESET_VECTOR]. The usable vector numbers can be found at the SOC header files, for example: msp430f5438a.h.</li>
+ * <li>Before executing an interrupt on a platform, refer to the chip manual of the platform.</li>
+ * </ul>
+ *
+ * @param  vector [IN] Type#int: hardware interrupt vector number. For example: WDT_VECTOR, RESET_VECTOR.
+ * @param  prio   [IN] Type#int: hardware interrupt priority. Not used.
+ * @param  mode   [IN] Type#int: hardware interrupt mode. Not used.
+ * @param  pfn    [IN] Type#void (*) (uintptr_t): interrupt handler used when a hardware interrupt is triggered.
+ * @param  arg    [IN] Type#uintptr_t: input parameter of the interrupt handler used when a hardware interrupt is triggered.
+ *
+ * @retval #OS_ERRNO_HWI_NUM_INVALID                  0x02000900: Invalid interrupt number.
+ * @retval #OS_ERRNO_HWI_PROC_FUNC_NULL               0x02000901: Null hardware interrupt handling function.
+ * @retval #OS_ERRNO_HWI_ALREADY_CREATED              0x02000904: The interrupt handler being created has already been created.
+ * @retval #LOS_OK                                    0x00000000: The interrupt is successfully created.
+ * @par Dependency:
+ * <ul><li>los_hwi.h: the header file that contains the API declaration.</li></ul>
+ * @see None.
+ * @since Huawei LiteOS V100R001C00
+ */
+extern UINT32 LOS_HwiCreate (int irq,int prio, int mode,
+                             void (*pfn) (uintptr_t),
+                             uintptr_t arg);
+
+/**
+ *@ingroup los_hwi
+ *@brief Enable all interrupts.
+ *
+ *@par Description:
+ *<ul>
+ *<li>This API is used to enable all interrupts.</li>
+ *</ul>
+ *@attention
+ *<ul>
+ *<li>None.</li>
+ *</ul>
+ *
+ *@param None.
+ *
+ *@retval original interrupt mask status.
+ *@par Dependency:
+ *<ul><li>los_hwi.h: the header file that contains the API declaration.</li></ul>
+ *@see LOS_IntRestore
+ *@since Huawei LiteOS V100R001C00
+ */
+extern uintptr_t LOS_IntUnLock (void);
+
+
+/**
+ *@ingroup los_hwi
+ *@brief Disable all interrupts.
+ *
+ *@par Description:
+ *<ul>
+ *<li>This API is used to disable all interrupts.</li>
+ *</ul>
+ *@attention
+ *<ul>
+ *<li>None.</li>
+ *</ul>
+ *
+ *@param None.
+ *
+ *@retval original interrupt mask status.
+ *@par Dependency:
+ *<ul><li>los_hwi.h: the header file that contains the API declaration.</li></ul>
+ *@see LOS_IntRestore
+ *@since Huawei LiteOS V100R001C00
+ */
+extern uintptr_t LOS_IntLock (void);
+
+
+/**
+ *@ingroup los_hwi
+ *@brief Restore interrupts.
+ *
+ *@par Description:
+ *<ul>
+ *<li>This API is used to restore the interrupt mask status.</li>
+ *</ul>
+ *@attention
+ *<ul>
+ *<li>This API can be called only after all interrupts are disabled, and the input parameter value should be the value returned by calling the all interrupt disabling API.</li>
+ *</ul>
+ *
+ *@param mask [IN] new interrupt mask.
+ *
+ *@retval None.
+ *@par Dependency:
+ *<ul><li>los_hwi.h: the header file that contains the API declaration.</li></ul>
+ *@see LOS_IntLock
+ *@since Huawei LiteOS V100R001C00
+ */
+extern void LOS_IntRestore (uintptr_t mask);
+
+
+/**
+ * @ingroup  los_hwi
+ * @brief Delete hardware interrupt.
+ *
+ * @par Description:
+ * This API is used to delete hardware interrupt vector handler.
+ *
+ * @attention
+ * <ul>
+ * <li>Hardware interrupt vector value range: [0, RESET_VECTOR].</li>
+ * <li>RESET_VECTOR specifies the maximum number of interrupts that can be created.</li>
+ * <li>Before executing an interrupt on a platform, refer to the chip manual of the platform.</li>
+ * </ul>
+ *
+ * @param  vector [IN] Type#int: hardware interrupt vector number.
+ *
+ * @retval #OS_ERRNO_HWI_NUM_INVALID              0x02000900: Invalid interrupt number.
+ * @retval #LOS_OK                                0x00000000: The interrupt is successfully delete.
+ * @par Dependency:
+ * <ul><li>los_hwi.h: the header file that contains the API declaration.</li></ul>
+ * @see None.
+ * @since Huawei LiteOS V100R001C00
+ */
+extern UINT32 LOS_HwiDelete (int vector);
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* __cplusplus */
+
+#endif /* _LOS_HWI_H */
+

--- a/arch/msp430/src/ccsmacros.h
+++ b/arch/msp430/src/ccsmacros.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------
- * Copyright (c) <2013-2015>, <Huawei Technologies Co., Ltd>
+ * Copyright (c) <2013-2018>, <Huawei Technologies Co., Ltd>
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -32,56 +32,44 @@
  * applicable export control laws and regulations.
  *---------------------------------------------------------------------------*/
 
-#include "los_base.ph"
-#include "los_sys.ph"
-#include "los_task.ph"
-#include "los_hwi.h"
+#ifndef _CCSMACROS_H
+#define _CCSMACROS_H
 
-LITE_OS_SEC_TEXT UINT32 LOS_Align(UINT32 uwAddr, UINT32 uwBoundary)
-{
-    if (uwAddr + uwBoundary - 1 > uwAddr) {
-        return (uwAddr + uwBoundary - 1) & ~(uwBoundary - 1);
-    } else {
-        return uwAddr & ~(uwBoundary - 1);
-    }
-}
+#if __LARGE_DATA_MODEL__ == 1
+#define PTR_SIZE        4
+#define PCMP            CMPX.A
+#define PMOV            MOVA
+#define PSUB            SUBX.A
+#else
+#define PTR_SIZE        2
+#define PCMP            CMP.W
+#define PMOV            MOV.W
+#define PSUB            SUB.W
+#endif
 
-LITE_OS_SEC_TEXT_MINOR VOID LOS_Msleep(UINT32 uwMsecs)
-{
-    UINT32 uwInterval = 0;
+#if __LARGE_CODE_MODEL__ == 1
+#define FRET            RETA
+#define FCALL           CALLA
+#else
+#define FRET            RET
+#define FCALL           CALL
+#endif
 
-    if (OS_INT_ACTIVE)
-    {
-        return;
-    }
-
-    if (uwMsecs == 0)
-    {
-        uwInterval = 0;
-    }
-    else
-    {
-        uwInterval = LOS_MS2Tick(uwMsecs);
-        if (uwInterval == 0)
-        {
-             uwInterval = 1;
-        }
-    }
-
-    (VOID)LOS_TaskDelay(uwInterval);
-}
-
-#if defined (__ICC430__) || defined (__TI_COMPILER_VERSION__)
-static const uint8_t clz_table_4bit[16] = { 4, 3, 2, 2, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0 };
-int __clz ( unsigned long x )
-{
-  int n;
-  if ((x & 0xFFFF0000) == 0) {n  = 16; x <<= 16;} else {n = 0;}
-  if ((x & 0xFF000000) == 0) {n +=  8; x <<=  8;}
-  if ((x & 0xF0000000) == 0) {n +=  4; x <<=  4;}
-  n += (int)clz_table_4bit[x >> (32-4)];
-  return n;
-}
+#if (__LARGE_DATA_MODEL__ == 1) || (__LARGE_CODE_MODEL__ == 1)
+#define REG_SIZE        4
+#define XMOV            MOVA
+#define XPUSH           PUSH.A
+#define XPUSHM          PUSHM.A
+#define XPOP            POP.A
+#define XPOPM           POPM.A
+#else
+#define REG_SIZE        2
+#define XMOV            MOV.W
+#define XPUSH           PUSH.W
+#define XPUSHM          PUSHM.W
+#define XPOP            POP.W
+#define XPOPM           POPM.W
+#endif
 
 #endif
 

--- a/arch/msp430/src/los_dispatch_ccs.asm
+++ b/arch/msp430/src/los_dispatch_ccs.asm
@@ -1,0 +1,291 @@
+;/*----------------------------------------------------------------------------
+; * Copyright (c) <2013-2018>, <Huawei Technologies Co., Ltd>
+; * All rights reserved.
+; * Redistribution and use in source and binary forms, with or without modification,
+; * are permitted provided that the following conditions are met:
+; * 1. Redistributions of source code must retain the above copyright notice, this list of
+; * conditions and the following disclaimer.
+; * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+; * of conditions and the following disclaimer in the documentation and/or other materials
+; * provided with the distribution.
+; * 3. Neither the name of the copyright holder nor the names of its contributors may be used
+; * to endorse or promote products derived from this software without specific prior written
+; * permission.
+; * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+; * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+; * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+; * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+; * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+; * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+; * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+; * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+; * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+; * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+; * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+; *---------------------------------------------------------------------------*/
+;/*----------------------------------------------------------------------------
+; * Notice of Export Control Law
+; * ===============================================
+; * Huawei LiteOS may be subject to applicable export control laws and regulations, which might
+; * include those applicable to Huawei LiteOS of U.S. and the country in which you are located.
+; * Import, export and usage of Huawei LiteOS in any manner by you shall be in compliance with such
+; * applicable export control laws and regulations.
+; *---------------------------------------------------------------------------*/
+
+        .cdecls C, LIST, "msp430.h"         ; Include device header file
+        .cdecls C, LIST, "ccsmacros.h"      ; Include macros used ccs header file
+
+        .data
+        .global _los_heap_start
+        .global _los_heap_end
+
+        .asg    256,    LOSCFG_MSP430_IRQ_SIZE
+
+        .align  4
+_los_heap_start:
+        .ulong  __HEAP_START
+_los_heap_end:
+        .ulong  __STACK_END - LOSCFG_MSP430_IRQ_SIZE
+
+        .text
+        .global RESET
+        .global LOS_IntLock
+        .global LOS_IntUnLock
+        .global LOS_IntRestore
+        .global LOS_StartToRun
+        .global osSchedule
+        .ref    g_bTaskScheduled
+        .ref    g_stLosTask
+        .ref    g_int_cnt
+        .ref    osTaskSwitchCheck
+        .ref    g_usLosTaskLock
+        .ref    osHwiDispatch
+        .retain
+        .retainrefs
+
+        .asg    0x10, TASK_STATUS_RUNNING
+
+;-------------------------------------------------------------------------------
+;       kernel entry
+;-------------------------------------------------------------------------------
+
+RESET:  MOV.W   #__STACK_END, sp
+        MOV.W   #WDTPW | WDTHOLD, &WDTCTL
+
+        NOP
+        BIS.W   #LPM0 | GIE, sr
+        NOP
+
+;-------------------------------------------------------------------------------
+;       irq vectors
+;-------------------------------------------------------------------------------
+
+        .asg    0, irq
+        .loop
+
+        .if irq < 10
+        .sect   ".int0:irq:"
+        .else
+        .sect   ".int:irq:"
+        .endif
+
+        .short  irq_stub:irq:
+
+        .eval   irq + 1, irq
+
+        .asg    irq + 1, irqs
+        .break ($symcmp (""".int:irq:""", SYSNMI_VECTOR) = 0)
+        .endloop
+
+;-------------------------------------------------------------------------------
+;       irq entry stubs
+;-------------------------------------------------------------------------------
+
+        .sect   ".text:_isr"
+
+        .asg    0, irq
+irq_stubs:
+    .loop   irqs
+irq_stub:irq:
+        FCALL   #irq_handler
+
+        .eval   irq + 1, irq
+    .endloop
+
+irq_handler:
+
+        ;
+        ; now the stack:
+        ;
+        ; +-------------------------+----+----+
+        ; | irq_stubs + irq * 4 + 4 | SR | PC |
+        ; +-------------------------+----+----+
+        ;
+
+        XPUSH   r14
+        XPUSH   r13
+        XPUSH   r12
+        XMOV    (3 * REG_SIZE)(sp), r12
+        XMOV    r15, (3 * REG_SIZE)(sp)
+
+        ;
+        ; now the stack:
+        ;
+        ; +-----+-----+-----+-----+----+----+
+        ; | R12 | R13 | R14 | R15 | SR | PC |
+        ; +-----+-----+-----+-----+----+----+
+        ;
+        ; now r12 = irq_stubs + irq * 4 + 4,
+        ;
+        ; ((r12 - (irq_stubs + 4)) / 4) is the irq number
+        ; ((r12 - (irq_stubs + 4)) / 2) is the vector number
+        ;
+
+        INC.B   &g_int_cnt
+        CMP.B   #1, &g_int_cnt
+        JNE     already_on_irq_stack
+
+        XMOV    sp, &__STACK_END - REG_SIZE
+        XMOV    #__STACK_END - REG_SIZE, sp
+already_on_irq_stack:
+
+        SUB.W   #irq_stubs + 4, r12             ; irq_stubs at CODE16
+        RRA.w   r12
+        RRA.w   r12
+
+        FCALL   #osHwiDispatch                  ; interrupt can be enabld in osHwiDispatch
+
+        DINT
+        NOP                                     ; required by architecture
+
+        DEC.B   &g_int_cnt
+        CMP.B   #0, &g_int_cnt
+        JNE     _rfi
+
+        XMOV    0(sp), sp
+
+        CMP.W   #0, &g_usLosTaskLock
+        JNE     _rfi
+
+        PCMP    &g_stLosTask + PTR_SIZE, &g_stLosTask
+        JEQ     _rfi            ; need schedule, save context
+
+        XPUSHM  #8, r11         ; save r4-r11
+
+_switch_new:
+
+        PMOV    &g_stLosTask, r12
+        PMOV    sp, 0(r12)
+        BIC.W   #TASK_STATUS_RUNNING, PTR_SIZE(r12)
+
+        FCALL   #osTaskSwitchCheck
+
+_load_new:
+        PMOV    &g_stLosTask + PTR_SIZE, r12
+        PMOV    r12, &g_stLosTask
+        PMOV    0(r12), sp
+        BIS.W   #TASK_STATUS_RUNNING, PTR_SIZE(r12)
+        XPOPM   #8, r11
+
+_rfi:
+        XPOPM   #4, r15
+        RETI
+
+LOS_StartToRun:
+        DINT
+        NOP                     ; required by architecture
+        MOV.W   #1, &g_bTaskScheduled
+        JMP     _load_new
+
+osSchedule:
+        MOV.W   sr, r12
+        DINT
+        NOP                     ; required by architecture
+        PCMP    &g_stLosTask + PTR_SIZE, &g_stLosTask
+        JEQ     _ret
+
+        .if __LARGE_CODE_MODEL__ = 1
+
+        ;
+        ; fake ra for calla as the same with interrupt:
+        ;
+        ; +---------+---------+    +----+----+
+        ; | ra00:15 | ra16:19 | -> | sr | ra |
+        ; +---------+---------+    +----+----+
+        ;
+        ; ra16:19 in sr16:19
+        ;
+
+        MOV.W   2(sp), r13
+        RLA     r13
+        RLA     r13
+        RLA     r13
+        RLA     r13
+        SWPB    r13
+        BIS.W   r13, r12
+
+        MOV.W   0(sp), 2(sp)
+        MOV.W   r12, 0(sp)
+
+        .else
+
+        PUSH.W  r12
+
+        .endif
+
+        PSUB    #4 * REG_SIZE, sp   ; reserve space for r12-r15, needless save
+
+        XPUSHM  #8, r11             ; save r4-r11
+
+        JMP     _switch_new
+
+_ret:
+        NOP                         ; required by architecture
+        MOV.W   r12, sr
+        NOP                         ; required by architecture
+        FRET
+
+LOS_IntLock:
+        MOV.W   sr, r12
+        AND.W   #GIE, r12
+        DINT
+        NOP                         ; required by architecture
+        FRET
+
+LOS_IntUnLock:
+        MOV.W   sr, r12
+        AND.W   #GIE, r12
+        NOP                         ; required by architecture
+        EINT
+        NOP
+        FRET
+
+LOS_IntRestore:
+        AND.W   #GIE, r12
+        NOP                         ; required by architecture
+        BIS.W   r12, sr
+        NOP                         ; required by architecture
+        FRET
+
+;-------------------------------------------------------------------------------
+;       System HEAP
+;-------------------------------------------------------------------------------
+
+        .sect   .sysmem
+        .align  8
+__HEAP_START:
+
+;-------------------------------------------------------------------------------
+;       Stack Pointer definition
+;-------------------------------------------------------------------------------
+
+        .global __STACK_END
+        .sect   .stack
+
+;-------------------------------------------------------------------------------
+;       Interrupt Vectors
+;-------------------------------------------------------------------------------
+        ;.sect   ".reset"
+        ;.short  RESET
+
+        .end

--- a/arch/msp430/src/los_dispatch_iar.s43
+++ b/arch/msp430/src/los_dispatch_iar.s43
@@ -1,0 +1,265 @@
+/*----------------------------------------------------------------------------
+ * Copyright (c) <2013-2018>, <Huawei Technologies Co., Ltd>
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific prior written
+ * permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------
+ * Notice of Export Control Law
+ * ===============================================
+ * Huawei LiteOS may be subject to applicable export control laws and regulations, which might
+ * include those applicable to Huawei LiteOS of U.S. and the country in which you are located.
+ * Import, export and usage of Huawei LiteOS in any manner by you shall be in compliance with such
+ * applicable export control laws and regulations.
+ *---------------------------------------------------------------------------*/
+
+#include "msp430.h"                     ; #define controlled include file
+#include "macros.m43"
+
+#include "target_config.h"
+
+        EXTERN  osHwiDispatch
+        EXTERN  g_int_cnt
+        EXTERN  g_stLosTask
+        EXTERN  g_bTaskScheduled
+        EXTERN  osTaskSwitchCheck
+        EXTERN  g_usLosTaskLock
+
+        PUBLIC  LOS_IntLock
+        PUBLIC  LOS_IntUnLock
+        PUBLIC  LOS_IntRestore
+        PUBLIC  LOS_StartToRun
+        PUBLIC  osSchedule
+        PUBLIC  _los_heap_start
+        PUBLIC  _los_heap_size
+
+#define TASK_STATUS_RUNNING             0x10
+
+#if __DATA_MODEL__ == __DATA_MODEL_LARGE__
+#define PTR_SIZE                        4
+#define PCMP    CMPX.A                  /* pointer compare */
+#define PMOV    MOVA                    /* pointer movation */
+#define PSUB    SUBX.A
+#else
+#define PTR_SIZE                        2
+#define PCMP    CMP.W                   /* pointer compare */
+#define PMOV    MOV.W                   /* pointer movation */
+#define PSUB    SUB.W
+#endif
+
+        /* forward declarations of segments */
+
+        RSEG    CSTACK:DATA:NOROOT
+        RSEG    DATA20_HEAP:DATA:NOROOT
+
+        NAME    los_dispatch            ; module name
+
+        /*
+         * create interrupt vector table for all interrupts
+         */
+
+        RSEG    INTVEC:CONST:CODE:ROOT(1)
+        ORG     0
+
+stub    SET     irq_stubs
+        REPT    RESET_VECTOR / 2 - 1
+        DC16    stub
+stub    SET     stub + 4
+        ENDR
+
+        ; entry (reset) at 0xfffe set by __program_start
+
+#ifndef LOSCFG_MSP430_IRQ_SIZE
+#define LOSCFG_MSP430_IRQ_SIZE          256
+#endif
+
+        RSEG    DATA16_C
+_los_heap_start
+        DC32    (sfe (DATA20_HEAP) + 7) & ~7
+_los_heap_size
+        DC32    ((sfe (CSTACK)) & ~7) - ((sfe (DATA20_HEAP) + 7) & ~7) - LOSCFG_MSP430_IRQ_SIZE
+
+        RSEG    CODE16                  ; place program in 'CODE16' segment
+
+irq_stubs:
+        REPT    RESET_VECTOR / 2 - 1
+#if REG_SIZE == 4
+        CALLA   #irq_handler
+#else
+        CALL    #irq_handler
+#endif
+        ENDR
+
+irq_handler:
+
+        /*
+         * now the stack:
+         *
+         * +-------------------------+----+----+
+         * | irq_stubs + irq * 4 + 4 | SR | PC |
+         * +-------------------------+----+----+
+         */
+
+        XPUSH   r14
+        XPUSH   r13
+        XPUSH   r12
+        XMOV    (3 * REG_SIZE)(sp), r12
+        XMOV    r15, (3 * REG_SIZE)(sp)
+
+        /*
+         * now the stack:
+         *
+         * +-----+-----+-----+-----+----+----+
+         * | R12 | R13 | R14 | R15 | SR | PC |
+         * +-----+-----+-----+-----+----+----+
+         *
+         * now r12 = irq_stubs + irq * 4 + 4,
+         * 
+         * ((r12 - (irq_stubs + 4)) / 4) is the irq number
+         * ((r12 - (irq_stubs + 4)) / 2) is the vector number
+         */
+
+        INC.B   &g_int_cnt
+        CMP.B   #1, &g_int_cnt
+        JNE     already_on_irq_stack
+
+        XMOV    sp, &sfe (CSTACK) - REG_SIZE
+        XMOV    #sfe (CSTACK) - REG_SIZE, sp
+
+already_on_irq_stack:
+
+        SUB.W   #irq_stubs + 4, r12             ; irq_stubs at CODE16
+        RRA.W   r12
+
+        FCALL   #osHwiDispatch                  ; interrupt can be enabld in osHwiDispatch
+
+        DINT
+        NOP                                     ; required by architecture
+
+        DEC.B   &g_int_cnt
+        CMP.B   #0, &g_int_cnt
+        JNE     _rfi
+
+        XMOV    0(sp), sp
+
+        CMP.W   #0, &g_usLosTaskLock
+        JNE     _rfi
+
+        PCMP    &g_stLosTask + PTR_SIZE, &g_stLosTask
+        JEQ     _rfi            ; need schedule, save context
+
+        XPUSHM  #8, r11         ; save r4-r11
+
+_switch_new:
+
+        PMOV    &g_stLosTask, r12
+        PMOV    sp, 0(r12)
+        BIC.W   #TASK_STATUS_RUNNING, PTR_SIZE(r12)
+
+        FCALL   #osTaskSwitchCheck
+
+_load_new:
+        PMOV    &g_stLosTask + PTR_SIZE, r12
+        PMOV    r12, &g_stLosTask
+        PMOV    0(r12), sp
+        BIS.W   #TASK_STATUS_RUNNING, PTR_SIZE(r12)
+        XPOPM   #8, r11
+
+_rfi:
+        XPOPM   #4, r15
+        RETI
+
+LOS_StartToRun:
+        DINT
+        NOP                     ; required by architecture
+        MOV.W   #1, &g_bTaskScheduled
+        JMP     _load_new
+
+osSchedule:
+        MOV.W   sr, r12
+        DINT
+        NOP                     ; required by architecture
+        PCMP    &g_stLosTask + PTR_SIZE, &g_stLosTask
+        JEQ     _ret
+
+#if __CODE_MODEL__ == __CODE_MODEL_LARGE__
+
+        /*
+         * fake ra for calla as the same with interrupt:
+         *
+         * +---------+---------+    +----+----+
+         * | ra00:15 | ra16:19 | -> | sr | ra |
+         * +---------+---------+    +----+----+
+         *
+         * ra16:19 in sr16:19
+         */
+
+        MOV.W   2(sp), r13
+        RLA     r13
+        RLA     r13
+        RLA     r13
+        RLA     r13
+        SWPB    r13
+        BIS.W   r13, r12
+
+        MOV.W   0(sp), 2(sp)
+        MOV.W   r12, 0(sp)
+#else
+        PUSH.W  r12
+#endif
+
+        PSUB    #4 * REG_SIZE, sp   ; reserve space for r12-r15, needless save
+
+        XPUSHM  #8, r11             ; save r4-r11
+
+        JMP     _switch_new
+
+_ret:
+        NOP                         ; required by architecture
+        MOV.W   r12, sr
+        NOP                         ; required by architecture
+        FRET
+
+LOS_IntLock:
+        MOV.W   sr, r12
+        AND.W   #GIE, r12
+        DINT
+        NOP                         ; required by architecture
+        FRET
+
+LOS_IntUnLock:
+        MOV.W   sr, r12
+        AND.W   #GIE, r12
+        NOP                         ; required by architecture
+        EINT
+        NOP
+        FRET
+
+LOS_IntRestore:
+        AND.W   #GIE, r12
+        NOP                         ; required by architecture
+        BIS.W   r12, sr
+        NOP                         ; required by architecture
+        FRET
+
+        END
+

--- a/arch/msp430/src/los_hw.c
+++ b/arch/msp430/src/los_hw.c
@@ -1,0 +1,137 @@
+/*----------------------------------------------------------------------------
+ * Copyright (c) <2013-2018>, <Huawei Technologies Co., Ltd>
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific prior written
+ * permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------
+ * Notice of Export Control Law
+ * ===============================================
+ * Huawei LiteOS may be subject to applicable export control laws and regulations, which might
+ * include those applicable to Huawei LiteOS of U.S. and the country in which you are located.
+ * Import, export and usage of Huawei LiteOS in any manner by you shall be in compliance with such
+ * applicable export control laws and regulations.
+ *---------------------------------------------------------------------------*/
+
+#include "los_base.h"
+#include "los_hwi.h"
+#include "los_task.ph"
+#include "los_memory.h"
+#include "los_membox.h"
+#include "los_priqueue.ph"
+
+void LOS_Schedule (void)
+{
+    uintptr_t flags;
+    BOOL      need_schedule = FALSE;
+
+    flags = LOS_IntLock ();
+
+    g_stLosTask.pstNewTask = LOS_DL_LIST_ENTRY (osPriqueueTop (),
+                                                LOS_TASK_CB, stPendList);/*lint !e413*/
+
+    need_schedule = (g_stLosTask.pstRunTask != g_stLosTask.pstNewTask) &&
+                    (!g_usLosTaskLock) && (!OS_INT_ACTIVE);
+
+    (void) LOS_IntRestore (flags);
+
+    if (need_schedule)
+    {
+        osSchedule ();
+    }
+}
+
+static void osTaskExit (void)
+{
+    LOS_IntUnLock();
+
+    while (1)
+    {
+        LOS_TaskDelay (0xffffffff);
+    };
+}
+
+/*****************************************************************************
+ Function    : osTskStackInit
+ Description : task stack initialization
+ Input       : tid        -- task id
+               stack_size -- task stack size
+               stack      -- task stack
+ Output      : None
+ Return      : OS_SUCCESS on success or error code on failure
+ *****************************************************************************/
+void * osTskStackInit (UINT32 tid, UINT32 stack_size, VOID * stack)
+{
+    TSK_CONTEXT_S * context;
+
+#if (LOSCFG_STATIC_TASK == NO)
+
+    UINT32 i;
+
+    /*initialize the task stack, write magic num to stack top*/
+
+    for (i = 0; i < (stack_size / sizeof (UINT32)); i++)
+    {
+        ((UINT32 *) stack) [i] = OS_TASK_STACK_INIT;
+    }
+
+    *((UINT32 *) stack) = OS_TASK_MAGIC_WORD;
+
+#endif
+
+    /* fake return address in stack */
+
+#if __CODE_MODEL__ == __CODE_MODEL_LARGE__
+    stack = (void *) (((char *) stack + stack_size) - 4);
+#else
+    stack = (void *) (((char *) stack + stack_size) - 2);
+#endif
+
+    *((void (**) (void)) stack) = osTaskExit;
+
+    /* make extra 4 bytes after the context to fake return address in stack */
+
+    context = (TSK_CONTEXT_S *) (((char *) stack) - sizeof (TSK_CONTEXT_S));
+
+    /*initialize the task context*/
+
+    context->pc  = ((((unsigned long) &osTaskEntry)) & 0xffff);
+
+#if __CODE_MODEL__ == __CODE_MODEL_LARGE__
+    context->sr  = ((((unsigned long) &osTaskEntry) >> 4) & 0xf000) | GIE;
+#else
+    context->sr  = GIE;
+#endif
+
+    context->r12 = tid;
+    context->r13 = 0;
+
+    return (void *) context;
+}
+
+#if (LOSCFG_KERNEL_RUNSTOP == YES)
+void osEnterSleep (void)
+{
+    //_BIS_SR (LPM0_bits + GIE);  /* Enter LPM0 w/ interrupt */
+}
+#endif
+

--- a/arch/msp430/src/los_hwi.c
+++ b/arch/msp430/src/los_hwi.c
@@ -1,0 +1,169 @@
+/*----------------------------------------------------------------------------
+ * Copyright (c) <2013-2018>, <Huawei Technologies Co., Ltd>
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific prior written
+ * permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------
+ * Notice of Export Control Law
+ * ===============================================
+ * Huawei LiteOS may be subject to applicable export control laws and regulations, which might
+ * include those applicable to Huawei LiteOS of U.S. and the country in which you are located.
+ * Import, export and usage of Huawei LiteOS in any manner by you shall be in compliance with such
+ * applicable export control laws and regulations.
+ *---------------------------------------------------------------------------*/
+
+#include "los_hwi.h"
+#include "los_memory.h"
+#include "string.h"
+
+unsigned char g_int_cnt = 0;
+
+
+#if defined (__ICC430__)
+
+static struct hwi_int_handle s_irq_table [RESET_VECTOR >> 1] = {0};
+
+#elif defined (__TI_COMPILER_VERSION__)
+
+static struct hwi_int_handle s_irq_table [RESET_VECTOR] = {0};
+
+#endif
+
+/*****************************************************************************
+ Function    : osHwiInit
+ Description : initialization of the hardware interrupt
+ Input       : None
+ Output      : None
+ Return      : None
+ *****************************************************************************/
+void osHwiInit (void)
+{
+    return;
+}
+
+void osHwiDispatch (int vector)
+{
+    int irq;
+
+    if ((vector < 0) || (vector >= RESET_VECTOR))
+    {
+        PRINT_ERR ("unexpected irq\n");
+        return;
+    }
+
+#if defined (__ICC430__)
+
+    irq = vector >> 1;
+
+#elif defined (__TI_COMPILER_VERSION__)
+
+    irq = vector;
+
+#endif
+
+    if (s_irq_table [irq].pfn == NULL)
+    {
+        PRINT_ERR ("unexpected irq\n");
+        return;
+    }
+
+    s_irq_table [irq].pfn (s_irq_table [irq].arg);
+}
+
+/*****************************************************************************
+ Function    : LOS_HwiCreate
+ Description : create hardware interrupt
+ Input       : vector --- vector number
+               prio   --- not used
+               pfn    --- vector handler
+               arg    --- param of the vector handler
+ Output      : None
+ Return      : OS_SUCCESS on success or error code on failure
+ *****************************************************************************/
+UINT32 LOS_HwiCreate (int vector, int prio, int mode,
+                      void (* pfn) (uintptr_t), uintptr_t arg)
+{
+    int     irq;
+
+    (void) mode;        /* not used for now */
+
+    if (pfn == NULL)
+    {
+        return OS_ERRNO_HWI_PROC_FUNC_NULL;
+    }
+
+    if ((vector < 0) || (vector >= RESET_VECTOR))
+    {
+        return OS_ERRNO_HWI_NUM_INVALID;
+    }
+
+#if defined (__ICC430__)
+
+    irq = vector >> 1;
+
+#elif defined (__TI_COMPILER_VERSION__)
+
+    irq = vector;
+
+#endif
+
+    if (s_irq_table [irq].pfn != NULL)
+    {
+        return OS_ERRNO_HWI_ALREADY_CREATED;
+    }
+
+    s_irq_table [irq].pfn = pfn;
+    s_irq_table [irq].arg = arg;
+
+    return 0;
+}
+
+
+/*****************************************************************************
+ Function    : LOS_HwiDelete
+ Description : delete hardware interrupt
+ Input       : vector --- hwi vector to delete
+ Output      : None
+ Return      : OS_SUCCESS on success or error code on failure
+ *****************************************************************************/
+UINT32 LOS_HwiDelete (int vector)
+{
+    if ((vector < 0) || (vector >= RESET_VECTOR))
+    {
+        return OS_ERRNO_HWI_NUM_INVALID;
+    }
+
+
+#if defined (__ICC430__)
+
+    s_irq_table [vector >> 1].pfn = NULL;
+
+#elif defined (__TI_COMPILER_VERSION__)
+
+    s_irq_table [vector].pfn = NULL;
+
+#endif
+
+    return LOS_OK;
+}
+

--- a/kernel/base/include/los_sem.ph
+++ b/kernel/base/include/los_sem.ph
@@ -43,12 +43,8 @@ extern "C" {
 #endif /* __cplusplus */
 #endif /* __cplusplus */
 
-
-enum LOS_SEM_MAX_COUNT
-{
-    OS_SEM_COUNTING_MAX_COUNT = 0xFFFF,       /*Max count of counting semaphores*/
-    OS_SEM_BINARY_MAX_COUNT   = 1           /*Max count of binary semaphores*/
-};
+#define OS_SEM_COUNTING_MAX_COUNT   0xFFFF
+#define OS_SEM_BINARY_MAX_COUNT     1
 
 /**
  * @ingroup los_sem

--- a/kernel/base/mem/bestfit_little/los_heap.c
+++ b/kernel/base/mem/bestfit_little/los_heap.c
@@ -155,13 +155,16 @@ LITE_OS_SEC_TEXT VOID* osHeapAlloc(VOID *pPool, UINT32 uwSz)
         pstNode->uwSize = pstBest->uwSize - uwSz- sizeof(struct LOS_HEAP_NODE);
         pstNode->pstPrev = pstBest;
 
-        if (pstBest != pstHeapMan->pstTail)
+        pstT = osHeapPrvGetNext(pstHeapMan, pstBest);
+
+        if (pstT == NULL)
         {
-            if ((pstT = osHeapPrvGetNext(pstHeapMan, pstNode)) != NULL)
-                pstT->pstPrev = pstNode;
+            pstHeapMan->pstTail = pstNode;      /* pstBest is tail */
         }
         else
-            pstHeapMan->pstTail = pstNode;
+        {
+            pstT->pstPrev = pstNode;
+        }
 
         pstBest->uwSize = uwSz;
     }
@@ -182,16 +185,13 @@ SIZE_MATCH:
     }
 #endif
 
+    g_uwAllocCount++;
+
 out:
     if (pstHeapMan->pstTail->uwSize < 1024)
         osAlarmHeapInfo(pstHeapMan);
 
     LOS_IntRestore(uvIntSave);
-
-    if (NULL != pRet)
-    {
-        g_uwAllocCount++;
-    }
 
     return pRet;
 }
@@ -287,7 +287,7 @@ LITE_OS_SEC_TEXT BOOL osHeapFree(VOID *pPool, VOID* pPtr)
         )))
     {
         bRet = FALSE;
-        goto OUT;
+        goto out;
     }
 
     /* set to unused status */
@@ -317,13 +317,10 @@ LITE_OS_SEC_TEXT BOOL osHeapFree(VOID *pPool, VOID* pPtr)
     if ((pstT = osHeapPrvGetNext(pstHeapMan, pstNode)) != NULL)
         pstT->pstPrev = pstNode;
 
-OUT:
-    LOS_IntRestore(uvIntSave);
+    g_uwFreeCount++;
 
-    if (TRUE == bRet)
-    {
-        g_uwFreeCount++;
-    }
+out:
+    LOS_IntRestore(uvIntSave);
 
     return bRet;
 }

--- a/kernel/include/los_compiler.h
+++ b/kernel/include/los_compiler.h
@@ -122,6 +122,60 @@ extern "C" {
   #define   CLZ                     __builtin_clz
   #endif
 
+#elif defined (__ICC430__)
+
+#ifndef   ASM
+  #define ASM                     __asm
+#endif
+
+#ifndef   INLINE
+  #define INLINE                  inline
+#endif
+
+#ifndef   STATIC_INLINE
+  #define STATIC_INLINE           static inline
+#endif
+
+#ifndef   USED
+  #define USED
+#endif
+
+#ifndef   WEAK
+  #define WEAK
+#endif
+
+#ifndef   CLZ
+  extern int __clz (unsigned long);
+  #define CLZ                     __clz
+#endif
+
+#elif defined (__TI_COMPILER_VERSION__)
+
+#ifndef   ASM
+  #define ASM                     __asm
+#endif
+
+#ifndef   INLINE
+  #define INLINE                  inline
+#endif
+
+#ifndef   STATIC_INLINE
+  #define STATIC_INLINE           static inline
+#endif
+
+#ifndef   USED
+  #define USED
+#endif
+
+#ifndef   WEAK
+  #define WEAK
+#endif
+
+#ifndef   CLZ
+  extern int __clz (unsigned long);
+  #define CLZ                     __clz
+#endif
+
 #else
   #error Unknown compiler.
 #endif

--- a/kernel/include/los_typedef.h
+++ b/kernel/include/los_typedef.h
@@ -53,10 +53,18 @@ extern "C" {
 /* type definitions */
 typedef unsigned char                                       UINT8;
 typedef unsigned short                                      UINT16;
+#if defined (__ICC430__) || defined (__TI_COMPILER_VERSION__)
+typedef unsigned long                                       UINT32;
+#else
 typedef unsigned int                                        UINT32;
+#endif
 typedef signed char                                         INT8;
 typedef signed short                                        INT16;
+#if defined (__ICC430__) || defined (__TI_COMPILER_VERSION__)
+typedef signed long                                         INT32;
+#else
 typedef signed int                                          INT32;
+#endif
 typedef float                                               FLOAT;
 typedef double                                              DOUBLE;
 typedef char                                                CHAR;

--- a/kernel/los_init.c
+++ b/kernel/los_init.c
@@ -35,9 +35,6 @@
 #include "los_tick.h"
 #include "los_task.ph"
 #include "los_config.h"
-#if (LOSCFG_KERNEL_RUNSTOP == YES)
-#include "los_sr.h"
-#endif
 
 #if (LOSCFG_PLATFORM_EXC == YES)
 #include "los_exc.ph"

--- a/targets/Standard_msp430f5438a_taurus_v4.2/OS_CONFIG/los_builddef.h
+++ b/targets/Standard_msp430f5438a_taurus_v4.2/OS_CONFIG/los_builddef.h
@@ -1,0 +1,239 @@
+/*----------------------------------------------------------------------------
+ * Copyright (c) <2016-2018>, <Huawei Technologies Co., Ltd>
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific prior written
+ * permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------
+ * Notice of Export Control Law
+ * ===============================================
+ * HuaweiLite OS may be subject to applicable export control laws and regulations, which might
+ * include those applicable to HuaweiLite OS of U.S. and the country in which you are located.
+ * Import, export and usage of HuaweiLite OS in any manner by you shall be in compliance with such
+ * applicable export control laws and regulations.
+ *---------------------------------------------------------------------------*/
+
+/**@defgroup los_builddef
+ * @ingroup kernel
+ */
+
+#ifndef _LOS_BUILDEF_H
+#define _LOS_BUILDEF_H
+#include "los_compiler.h"
+#include "string.h"
+#ifdef __cplusplus
+#if __cplusplus
+extern "C" {
+#endif /* __cpluscplus */
+#endif /* __cpluscplus */
+
+/**
+ * @ingroup los_builddef
+ * Define inline keyword
+ */
+
+/**
+ * @ingroup los_builddef
+ * Little endian
+ */
+#define OS_LITTLE_ENDIAN                    0x1234
+
+/**
+ * @ingroup los_builddef
+ * Big endian
+ */
+#define OS_BIG_ENDIAN                       0x4321
+
+/**
+ * @ingroup los_builddef
+ * Byte order
+ */
+#ifndef OS_BYTE_ORDER
+#define OS_BYTE_ORDER                       OS_LITTLE_ENDIAN
+#endif
+
+/* Define OS code data sections */
+/*The indicator function is inline*/
+
+/**
+ * @ingroup los_builddef
+ * Allow inline sections
+ */
+#ifndef LITE_OS_SEC_ALW_INLINE
+#define LITE_OS_SEC_ALW_INLINE              //__attribute__((always_inline))
+#endif
+
+/**
+ * @ingroup los_builddef
+ * Vector table section
+ */
+#ifndef LITE_OS_SEC_VEC
+#define LITE_OS_SEC_VEC                     __attribute__ ((section(".data.vector")))
+#endif
+
+/**
+ * @ingroup los_builddef
+ * .Text section (Code section)
+ */
+#ifndef LITE_OS_SEC_TEXT
+#define LITE_OS_SEC_TEXT                    //__attribute__((section(".sram.text")))
+#endif
+
+/**
+ * @ingroup los_builddef
+ * .Text.ddr section
+ */
+#ifndef LITE_OS_SEC_TEXT_MINOR
+#define LITE_OS_SEC_TEXT_MINOR              //__attribute__((section(".dyn.text")))
+#endif
+
+/**
+ * @ingroup los_builddef
+ * .Text.init section
+ */
+#ifndef LITE_OS_SEC_TEXT_INIT
+#define LITE_OS_SEC_TEXT_INIT               //__attribute__((section(".dyn.text")))
+#endif
+
+/**
+ * @ingroup los_builddef
+ * Redirect .Text  section (Code section)
+ */
+#ifndef LITE_OS_SEC_TEXT_REDIRECT
+#define LITE_OS_SEC_TEXT_REDIRECT           LITE_OS_SEC_TEXT
+#endif
+
+/**
+ * @ingroup los_builddef
+ * Redirect .Text.ddr section
+ */
+#ifndef LITE_OS_SEC_TEXT_MINOR_REDIRECT
+#define LITE_OS_SEC_TEXT_MINOR_REDIRECT     LITE_OS_SEC_TEXT_MINOR
+#endif
+
+/**
+ * @ingroup los_builddef
+ * Redirect .Text.init section
+ */
+#ifndef LITE_OS_SEC_TEXT_INIT_REDIRECT
+#define LITE_OS_SEC_TEXT_INIT_REDIRECT      LITE_OS_SEC_TEXT_INIT
+#endif
+
+/**
+ * @ingroup los_builddef
+ * .Data section
+ */
+#ifndef LITE_OS_SEC_DATA
+#define LITE_OS_SEC_DATA                    //__attribute__((section(".dyn.data")))
+#endif
+
+/**
+ * @ingroup los_builddef
+ * .Data.init section
+ */
+#ifndef LITE_OS_SEC_DATA_INIT
+#define LITE_OS_SEC_DATA_INIT               //__attribute__((section(".dyn.data")))
+#endif
+
+/**
+ * @ingroup los_builddef
+ * Not initialized variable section
+ */
+#ifndef LITE_OS_SEC_BSS
+#define LITE_OS_SEC_BSS                     //__attribute__((section(".sym.bss")))
+#endif
+
+/**
+ * @ingroup los_builddef
+ * .bss.ddr section
+ */
+#ifndef LITE_OS_SEC_BSS_MINOR
+#define LITE_OS_SEC_BSS_MINOR
+#endif
+
+/**
+ * @ingroup los_builddef
+ * .bss.init sections
+ */
+#ifndef LITE_OS_SEC_BSS_INIT
+#define LITE_OS_SEC_BSS_INIT
+#endif
+
+#ifndef LITE_OS_SEC_TEXT_DATA
+#define LITE_OS_SEC_TEXT_DATA               //__attribute__((section(".dyn.data")))
+#define LITE_OS_SEC_TEXT_BSS                //__attribute__((section(".dyn.bss")))
+#define LITE_OS_SEC_TEXT_RODATA             //__attribute__((section(".dyn.rodata")))
+#endif
+
+#ifndef LITE_OS_SEC_SYMDATA
+#define LITE_OS_SEC_SYMDATA                 //__attribute__((section(".sym.data")))
+#endif
+
+#ifndef LITE_OS_SEC_SYMBSS
+#define LITE_OS_SEC_SYMBSS                  //__attribute__((section(".sym.bss")))
+#endif
+
+
+#ifndef LITE_OS_SEC_KEEP_DATA_DDR
+#define LITE_OS_SEC_KEEP_DATA_DDR           //__attribute__((section(".keep.data.ddr")))
+#endif
+
+#ifndef LITE_OS_SEC_KEEP_TEXT_DDR
+#define LITE_OS_SEC_KEEP_TEXT_DDR           //__attribute__((section(".keep.text.ddr")))
+#endif
+
+#ifndef LITE_OS_SEC_KEEP_DATA_SRAM
+#define LITE_OS_SEC_KEEP_DATA_SRAM          //__attribute__((section(".keep.data.sram")))
+#endif
+
+#ifndef LITE_OS_SEC_KEEP_TEXT_SRAM
+#define LITE_OS_SEC_KEEP_TEXT_SRAM          //__attribute__((section(".keep.text.sram")))
+#endif
+
+#ifndef LITE_OS_SEC_BSS_MINOR
+#define LITE_OS_SEC_BSS_MINOR
+#endif
+
+/**
+ * @ingroup los_builddef
+ * .text.libsec section
+ */
+#ifndef LIB_SECURE_SEC_TEXT
+#define LIB_SECURE_SEC_TEXT
+#endif
+
+/**
+ * @ingroup los_builddef
+ * .text.libc section
+ */
+#ifndef LIBC_SEC_TEXT
+#define LIBC_SEC_TEXT
+#endif
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif /* __cpluscplus */
+#endif /* __cpluscplus */
+
+
+#endif /* _LOS_BUILDEF_H */

--- a/targets/Standard_msp430f5438a_taurus_v4.2/OS_CONFIG/los_printf.h
+++ b/targets/Standard_msp430f5438a_taurus_v4.2/OS_CONFIG/los_printf.h
@@ -1,0 +1,112 @@
+/*----------------------------------------------------------------------------
+ * Copyright (c) <2016-2018>, <Huawei Technologies Co., Ltd>
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific prior written
+ * permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------
+ * Notice of Export Control Law
+ * ===============================================
+ * Huawei LiteOS may be subject to applicable export control laws and regulations, which might
+ * include those applicable to Huawei LiteOS of U.S. and the country in which you are located.
+ * Import, export and usage of Huawei LiteOS in any manner by you shall be in compliance with such
+ * applicable export control laws and regulations.
+ *---------------------------------------------------------------------------*/
+
+/**@defgroup los_printf Printf
+ * @ingroup kernel
+ */
+
+#ifndef _LOS_PRINTF_H
+#define _LOS_PRINTF_H
+//#ifdef LOSCFG_LIB_LIBC
+#include "stdarg.h"
+//#endif
+#ifdef LOSCFG_LIB_LIBCMINI
+#include "libcmini.h"
+#endif
+#include "los_typedef.h"
+#include "los_config.h"
+#include "stdio.h"
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+#endif /* __cplusplus */
+
+#define LOS_EMG_LEVEL           (0)
+
+#define LOS_COMMOM_LEVEL        (LOS_EMG_LEVEL + 1)
+#define LOS_ERR_LEVEL           (LOS_COMMOM_LEVEL + 1)
+#define LOS_WARN_LEVEL          (LOS_ERR_LEVEL + 1)
+#define LOS_INFO_LEVEL          (LOS_WARN_LEVEL + 1)
+#define LOS_DEBUG_LEVEL         (LOS_INFO_LEVEL + 1)
+
+#define PRINT_LEVEL             (0)
+
+#if PRINT_LEVEL < LOS_DEBUG_LEVEL
+#define PRINT_DEBUG(...)
+#else
+#define PRINT_DEBUG(...)        do{(printf("[DEBUG] "), printf(__VA_ARGS__));}while(0)
+#endif
+
+#if PRINT_LEVEL < LOS_INFO_LEVEL
+#define PRINT_INFO(...)
+#else
+#define PRINT_INFO(...)         do{(printf("[INFO] "), printf(__VA_ARGS__));}while(0)
+#endif
+
+#if PRINT_LEVEL < LOS_WARN_LEVEL
+#define PRINT_WARN(args, ...)
+#else
+#define PRINT_WARN(...)         do{(printf("[WARN] "), printf(__VA_ARGS__));}while(0)
+#endif
+
+#if PRINT_LEVEL < LOS_ERR_LEVEL
+#define PRINT_ERR(...)
+#else
+#define PRINT_ERR(...)          do{(printf("[ERR] "), printf(__VA_ARGS__));}while(0)
+#endif
+
+#if PRINT_LEVEL < LOS_COMMOM_LEVEL
+#define PRINTK(...)
+#else
+#define PRINTK(...)             printf(__VA_ARGS__)
+#endif
+
+#if PRINT_LEVEL < LOS_EMG_LEVEL
+#define PRINT_EMG(args, ...)
+#else
+#define PRINT_EMG(...)          do{(printf("[EMG] "), printf(__VA_ARGS__));}while(0)
+#endif
+
+#define PRINT_RELEASE(...)      printf(__VA_ARGS__)
+
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* __cplusplus */
+
+#endif /* _LOS_PRINTF_H */

--- a/targets/Standard_msp430f5438a_taurus_v4.2/OS_CONFIG/target_config.h
+++ b/targets/Standard_msp430f5438a_taurus_v4.2/OS_CONFIG/target_config.h
@@ -1,0 +1,414 @@
+/*----------------------------------------------------------------------------
+ * Copyright (c) <2016-2018>, <Huawei Technologies Co., Ltd>
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific prior written
+ * permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------
+ * Notice of Export Control Law
+ * ===============================================
+ * Huawei LiteOS may be subject to applicable export control laws and regulations, which might
+ * include those applicable to Huawei LiteOS of U.S. and the country in which you are located.
+ * Import, export and usage of Huawei LiteOS in any manner by you shall be in compliance with such
+ * applicable export control laws and regulations.
+ *---------------------------------------------------------------------------*/
+
+/**@defgroup los_config System configuration items
+ * @ingroup kernel
+ */
+
+#ifndef _TARGET_CONFIG_H
+#define _TARGET_CONFIG_H
+
+#include "msp430.h"
+
+#ifndef __A430__
+#include "los_typedef.h"
+#endif
+
+#ifdef __cplusplus
+#if __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+#endif /* __cplusplus */
+
+/*=============================================================================
+                                        System clock module configuration
+=============================================================================*/
+
+/**
+ * @ingroup los_config
+ * System clock (unit: HZ)
+ */
+#define OS_SYS_CLOCK                                        (10240000)
+
+/**
+ * @ingroup los_config
+ * Number of Ticks in one second
+ */
+#define LOSCFG_BASE_CORE_TICK_PER_SECOND                    (20UL)
+
+/**
+ * @ingroup los_config
+ * External configuration item for timer tailoring
+ */
+#define LOSCFG_BASE_CORE_TICK_HW_TIME                       NO
+
+/**
+ * @ingroup los_config
+ * Configuration liteos kernel tickless
+ */
+#define LOSCFG_KERNEL_TICKLESS                              NO
+
+/*=============================================================================
+                                        Hardware interrupt module configuration
+=============================================================================*/
+
+/**
+ * @ingroup los_config
+ * Configuration item for hardware interrupt tailoring
+ */
+#define LOSCFG_PLATFORM_HWI                                 YES
+
+/**
+ * @ingroup los_config
+ * Maximum number of used hardware interrupts.
+ */
+#define LOSCFG_PLATFORM_HWI_LIMIT                           64
+
+
+/*=============================================================================
+                                       Task module configuration
+=============================================================================*/
+
+/**
+ * @ingroup los_config
+ * Default task priority
+ */
+#define LOSCFG_BASE_CORE_TSK_DEFAULT_PRIO                   10
+
+/**
+ * @ingroup los_config
+ * Maximum supported number of tasks except the idle task rather than the number of usable tasks
+ */
+#define LOSCFG_BASE_CORE_TSK_LIMIT                          15
+
+/**
+ * @ingroup los_config
+ * Size of the idle task stack
+ */
+#define LOSCFG_BASE_CORE_TSK_IDLE_STACK_SIZE                (0x50U)
+
+/**
+ * @ingroup los_config
+ * Default task stack size
+ */
+#define LOSCFG_BASE_CORE_TSK_DEFAULT_STACK_SIZE             (0x2D0U)
+
+/**
+ * @ingroup los_config
+ * Minimum stack size.
+ */
+#define LOSCFG_BASE_CORE_TSK_MIN_STACK_SIZE                 (0x50)
+
+/**
+ * @ingroup los_config
+ * Configuration item for task Robin tailoring
+ */
+#define LOSCFG_BASE_CORE_TIMESLICE                          YES
+
+/**
+ * @ingroup los_config
+ * Longest execution time of tasks with the same priorities
+ */
+#define LOSCFG_BASE_CORE_TIMESLICE_TIMEOUT                  10
+
+/**
+ * @ingroup los_config
+ * Configuration item for task (stack) monitoring module tailoring
+ */
+#define LOSCFG_BASE_CORE_TSK_MONITOR                        YES
+
+/**
+ * @ingroup los_config
+ * Configuration item for task perf task filter hook
+ */
+#define LOSCFG_BASE_CORE_EXC_TSK_SWITCH                     YES
+
+/**
+ * @ingroup los_config
+ * Configuration item for performance moniter unit
+ */
+#define OS_INCLUDE_PERF                                     YES
+
+/**
+ * @ingroup los_config
+ * Define a usable task priority.Highest task priority.
+ */
+#define LOS_TASK_PRIORITY_HIGHEST                           0
+
+/**
+ * @ingroup los_config
+ * Define a usable task priority.Lowest task priority.
+ */
+#define LOS_TASK_PRIORITY_LOWEST                            31
+
+
+/*=============================================================================
+                                       Semaphore module configuration
+=============================================================================*/
+
+/**
+ * @ingroup los_config
+ * Configuration item for semaphore module tailoring
+ */
+#define LOSCFG_BASE_IPC_SEM                                 YES
+
+/**
+ * @ingroup los_config
+ * Maximum supported number of semaphores
+ */
+#define LOSCFG_BASE_IPC_SEM_LIMIT                           20
+
+
+/*=============================================================================
+                                       Mutex module configuration
+=============================================================================*/
+
+/**
+ * @ingroup los_config
+ * Configuration item for mutex module tailoring
+ */
+#define LOSCFG_BASE_IPC_MUX                                 YES
+
+/**
+ * @ingroup los_config
+ * Maximum supported number of mutexes
+ */
+#define LOSCFG_BASE_IPC_MUX_LIMIT                           15
+
+
+/*=============================================================================
+                                       Queue module configuration
+=============================================================================*/
+
+/**
+ * @ingroup los_config
+ * Configuration item for queue module tailoring
+ */
+#define LOSCFG_BASE_IPC_QUEUE                               YES
+
+/**
+ * @ingroup los_config
+ * Maximum supported number of queues rather than the number of usable queues
+ */
+#define LOSCFG_BASE_IPC_QUEUE_LIMIT                         10
+
+
+/*=============================================================================
+                                       Software timer module configuration
+=============================================================================*/
+
+#if (LOSCFG_BASE_IPC_QUEUE == YES)
+/**
+ * @ingroup los_config
+ * Configuration item for software timer module tailoring
+ */
+#define LOSCFG_BASE_CORE_SWTMR                              YES
+
+#define LOSCFG_BASE_CORE_TSK_SWTMR_STACK_SIZE               LOSCFG_BASE_CORE_TSK_DEFAULT_STACK_SIZE
+
+#define LOSCFG_BASE_CORE_SWTMR_TASK                         YES
+
+#define LOSCFG_BASE_CORE_SWTMR_ALIGN                        YES
+#if (LOSCFG_BASE_CORE_SWTMR == NO && LOSCFG_BASE_CORE_SWTMR_ALIGN == YES)
+    #error "swtmr align first need support swmtr, should make LOSCFG_BASE_CORE_SWTMR = YES"
+#endif
+
+/**
+ * @ingroup los_config
+ * Maximum supported number of software timers rather than the number of usable software timers
+ */
+#define LOSCFG_BASE_CORE_SWTMR_LIMIT                        16
+
+/**
+ * @ingroup los_config
+ * Max number of software timers ID
+ */
+#define OS_SWTMR_MAX_TIMERID                                ((65535/LOSCFG_BASE_CORE_SWTMR_LIMIT) * LOSCFG_BASE_CORE_SWTMR_LIMIT)
+
+/**
+ * @ingroup los_config
+ * Maximum size of a software timer queue
+ */
+#define OS_SWTMR_HANDLE_QUEUE_SIZE                          (LOSCFG_BASE_CORE_SWTMR_LIMIT + 0)
+
+/**
+ * @ingroup los_config
+ * Minimum divisor of software timer multiple alignment
+ */
+#define LOS_COMMON_DIVISOR                                  10
+#endif
+
+
+/*=============================================================================
+                                       Memory module configuration
+=============================================================================*/
+
+#ifndef __A430__
+extern unsigned long _los_heap_start;
+
+#ifdef __ICC430__
+extern unsigned long _los_heap_size;
+#endif
+
+#ifdef __TI_COMPILER_VERSION__
+extern unsigned long _los_heap_end;
+#endif
+#endif
+
+/**
+ * @ingroup los_config
+ * Starting address of the memory
+ */
+#define OS_SYS_MEM_ADDR                                     (VOID *) _los_heap_start
+
+
+/**
+ * @ingroup los_config
+ * Memory size
+ */
+#ifdef __ICC430__
+#define OS_SYS_MEM_SIZE                                     (_los_heap_size)
+#endif
+
+#ifdef __TI_COMPILER_VERSION__
+#define OS_SYS_MEM_SIZE                                     (_los_heap_end - _los_heap_start)
+#endif
+
+/**
+ * @ingroup los_config
+ * Configuration module tailoring of mem node integrity checking
+ */
+#define LOSCFG_BASE_MEM_NODE_INTEGRITY_CHECK                YES
+
+/**
+ * @ingroup los_config
+ * Configuration module tailoring of mem node size checking
+ */
+#define LOSCFG_BASE_MEM_NODE_SIZE_CHECK                     YES
+
+#define LOSCFG_MEMORY_BESTFIT                               YES
+
+/**
+ * @ingroup los_config
+ * Configuration module tailoring of more mempry pool checking
+ */
+#define LOSCFG_MEM_MUL_POOL                                 NO
+
+/**
+ * @ingroup los_config
+ * Number of memory checking blocks
+ */
+#define OS_SYS_MEM_NUM                                      20
+
+/**
+ * @ingroup los_config
+ * Configuration module tailoring of slab memory
+ */
+#define LOSCFG_KERNEL_MEM_SLAB                              YES
+
+
+/*=============================================================================
+                                       fw Interface configuration
+=============================================================================*/
+
+/**
+ * @ingroup los_config
+ * Configuration item for the monitoring of task communication
+ */
+#define LOSCFG_COMPAT_CMSIS_FW                              YES
+
+
+/*=============================================================================
+                                       others
+=============================================================================*/
+
+/**
+ * @ingroup los_config
+ * Configuration system wake-up info to open
+ */
+#define OS_SR_WAKEUP_INFO                                   YES
+
+/**
+ * @ingroup los_config
+ * Configuration CMSIS_OS_VER
+ */
+#define CMSIS_OS_VER                                        2
+
+
+/*=============================================================================
+                                        Exception module configuration
+=============================================================================*/
+
+/**
+ * @ingroup los_config
+ * Configuration item for exception tailoring
+ */
+#define LOSCFG_PLATFORM_EXC                                 NO
+
+
+/*=============================================================================
+                                       Runstop module configuration
+=============================================================================*/
+
+/**
+ * @ingroup los_config
+ * Configuration item for runstop module tailoring
+ */
+#define LOSCFG_KERNEL_RUNSTOP                               YES
+
+
+/*=============================================================================
+                                        track configuration
+=============================================================================*/
+
+/**
+ * @ingroup los_config
+ * Configuration item for track
+ */
+#define LOSCFG_BASE_MISC_TRACK                              NO
+
+/**
+ * @ingroup los_config
+ * Max count of track items
+ */
+#define LOSCFG_BASE_MISC_TRACK_MAX_COUNT                    1024
+
+#ifdef __cplusplus
+#if __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* __cplusplus */
+
+
+#endif /* _TARGET_CONFIG_H */

--- a/targets/Standard_msp430f5438a_taurus_v4.2/README.md
+++ b/targets/Standard_msp430f5438a_taurus_v4.2/README.md
@@ -1,0 +1,91 @@
+Standard_msp430f5438a_taurus_v4.2支持IAR和TI官方的CCS（Code Composer Studio），这里介绍TI CCS下的工程创建过程。
+
+
+
+# 安装TI CCS
+
+TI CCS的安装比较简单，这里就不详细介绍了。
+
+
+
+# 创建工程
+
+## 新建workspace
+
+打开TI CCS IDE，它会提示选择“Workspace”的目录，这里指定合适的目录，比如：
+
+> C:\Users\your-username\ccs-wb
+
+然后点击“Launch”。
+
+这个时候会看到CCS的“Getting Started”页面。
+
+## 新建CCS工程
+
+1. 依次点击菜单栏“Project”->“New CCS Project...”
+
+2. “Target”选择“MSP430x5xx Family”，然后在紧随的下拉列表里选择“MSP430F5438A”
+
+3. “Project Name”填入“Huawei_LiteOS”
+
+4. 去掉“Use default location”选项，在当前target目录下创建工程，比如：
+
+   > D:\LiteOS\targets\Standard_msp430f5438a_taurus_v4.2\CCS
+
+5. “Compiler version"选择TI的编译器，比如：`TI v18.1.2.LTS`
+
+6. “Tool-chain”相关设置保持默认
+
+7. “Project templates and examples”处选择“Empty Project”
+
+8. 完成以上步骤后，点击最下方的“Finish”按钮
+
+完成以上步骤后我们我们的工程就创建好了。
+
+## 添加代码
+
+1. 创建需要的目录右键我们的工程依次选择“New”->“Folder”，“Folder name:“处输入”arch“，然后点击”Advanced >>“选择”Link to alternate location (Linked Folder)“。然后输入MSP430的arch源代码目录路径，比如：
+
+   > D:\LiteOS\arch\msp430\src
+
+   然后点击最下方的"Finish"按钮
+
+2. 完成以上步骤后就可以看到创建的目录了，然后展开”arch“目录，右键点击”los_dispatch_iar.s43“文件，然后点击”Exclude from Build“
+
+3. 使用步骤1中的方法添加”kernel“目录，并”link“到kernel的目录（比如：`D:\LiteOS\kernel`）
+
+4. 展开”kernel->base->mem“目录，右键点击”bestfit“目录，然后点击”Exclude from Build“，同样的方法去掉”tlsf“目录和”kernel->extended“目录
+
+5. 使用类似前面几步的方法添加名为”src“的目录，并且link到”Standard_msp430f5438a_taurus_v4.2“下的“SRC”目录，比如：
+
+   > D:\LiteOS\targets\Standard_msp430f5438a_taurus_v4.2\SRC
+
+### 添加”include“目录
+
+邮件点击工程名，然后选择”Properites“。找到”Build“->”MSP430 Compiler“->”Include Options“，在弹出的对话框中依次添加如下头文件目录：
+
+> ${PROJECT_ROOT}/../../../kernel/include
+> ${PROJECT_ROOT}/../../../kernel/base/include
+> ${PROJECT_ROOT}/../OS_CONFIG
+> ${PROJECT_ROOT}/../../../arch/msp430/include
+> ${PROJECT_ROOT}/../../../kernel/extended/include
+
+最后点击”Apply and Close“
+
+## 编译及下载
+
+完成前面的步骤后编译工程以及连接仿真器下载调试了。在这里不再赘述。
+
+## 注意事项
+
+Huawei LiteOS的中断管理会接管所有的外部中断，请使用标准API注册中断处理函数，比如：
+
+> LOS_HwiCreate (USCI_A0_VECTOR, 0, 0, uart_isr, 0);
+>
+> LOS_HwiCreate (TIMER1_A0_VECTOR, 0, 0, (void (*) (uintptr_t)) osTickHandler, 0);
+
+`USCI_A0_VECTOR`，`TIMER1_A0_VECTOR`这些vector号的定义请查询IAR或CCS的SDK中的`msp430f5438a.h`。
+
+
+
+目前Huawei LiteOS仅支持基本的设备：timer a用作系统时钟，简单的uart驱动支持。

--- a/targets/Standard_msp430f5438a_taurus_v4.2/SRC/main.c
+++ b/targets/Standard_msp430f5438a_taurus_v4.2/SRC/main.c
@@ -1,0 +1,161 @@
+/*----------------------------------------------------------------------------
+ * Copyright (c) <2016-2018>, <Huawei Technologies Co., Ltd>
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific prior written
+ * permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------
+ * Notice of Export Control Law
+ * ===============================================
+ * Huawei LiteOS may be subject to applicable export control laws and regulations, which might
+ * include those applicable to Huawei LiteOS of U.S. and the country in which you are located.
+ * Import, export and usage of Huawei LiteOS in any manner by you shall be in compliance with such
+ * applicable export control laws and regulations.
+ *---------------------------------------------------------------------------*/
+
+#include "los_task.h"
+#include "msp430.h"
+
+UINT32 g_TskHandle;
+
+extern UINT32 uart_init (void);
+extern void uart_puts (unsigned char * str);
+extern void uart_putc (unsigned char ch);
+extern unsigned char uart_getc (void);
+
+static void HardWare_Init (void)
+{
+    WDTCTL = WDTPW + WDTHOLD;
+}
+
+void task1 (void)
+{
+    int i;
+
+    for (;;) {
+        for (i = 0; i < 20; i++)
+        {
+            uart_putc ('1');
+        }
+
+        LOS_TaskDelay (5);
+    }
+}
+
+void task2 (void)
+{
+    for (;;) {
+        uart_putc ('2');
+    }
+}
+
+void task3 (void)
+{
+    for (;;) {
+        uart_putc ('3');
+    }
+}
+
+void rxtxt (void)
+{
+    unsigned char ch;
+
+    for (;;) {
+        ch = uart_getc ();
+        uart_putc (ch);
+    }
+}
+
+UINT32 creat_main_task()
+{
+    UINT32 uwRet = LOS_OK;
+    TSK_INIT_PARAM_S task_init_param;
+
+    task_init_param.usTaskPrio = 1;
+    task_init_param.pcName = "t1";
+    task_init_param.pfnTaskEntry = (TSK_ENTRY_FUNC)task1;
+    task_init_param.uwStackSize = 0x100;
+
+    uwRet = LOS_TaskCreate(&g_TskHandle, &task_init_param);
+    if(LOS_OK != uwRet)
+    {
+        return uwRet;
+    }
+
+    task_init_param.usTaskPrio = 2;
+    task_init_param.pcName = "t2";
+    task_init_param.pfnTaskEntry = (TSK_ENTRY_FUNC)task2;
+
+    uwRet = LOS_TaskCreate(&g_TskHandle, &task_init_param);
+    if(LOS_OK != uwRet)
+    {
+        return uwRet;
+    }
+
+    task_init_param.pcName = "t3";
+    task_init_param.pfnTaskEntry = (TSK_ENTRY_FUNC)task3;
+
+    uwRet = LOS_TaskCreate(&g_TskHandle, &task_init_param);
+    if(LOS_OK != uwRet)
+    {
+        return uwRet;
+    }
+
+    task_init_param.usTaskPrio = 0;
+    task_init_param.pcName = "rx-tx-test";
+    task_init_param.pfnTaskEntry = (TSK_ENTRY_FUNC)rxtxt;
+
+    uwRet = LOS_TaskCreate(&g_TskHandle, &task_init_param);
+    if(LOS_OK != uwRet)
+    {
+        return uwRet;
+    }
+
+    return uwRet;
+}
+
+int main(void)
+{
+    UINT32 uwRet = LOS_OK;
+    HardWare_Init();
+
+    uwRet = LOS_KernelInit();
+    if (uwRet != LOS_OK)
+    {
+        return LOS_NOK;
+    }
+
+    uart_init ();
+
+    uwRet = creat_main_task();
+    if (uwRet != LOS_OK)
+    {
+        return LOS_NOK;
+    }
+
+    uart_puts ("\nHuawei LiteOS on MSP430F5438A\n");
+
+    (void)LOS_Start();
+
+    return 0;
+}
+

--- a/targets/Standard_msp430f5438a_taurus_v4.2/SRC/uart.c
+++ b/targets/Standard_msp430f5438a_taurus_v4.2/SRC/uart.c
@@ -1,0 +1,234 @@
+#include <msp430.h>
+#include <los_typedef.h>
+#include <los_hwi.h>
+#include <los_task.h>
+#include <los_sem.h>
+
+#define TX_RING_SIZE    256
+#define RX_RING_SIZE    256
+
+static UINT32 s_rxsem = LOS_ERRNO_SEM_PTR_NULL;
+static UINT32 s_txsem = LOS_ERRNO_SEM_PTR_NULL;
+
+struct ring
+{
+    unsigned char * buff;                   // ring buff
+    unsigned char   mask;
+    unsigned char   head;
+    unsigned char   tail;
+};
+
+static unsigned char tx_buff [TX_RING_SIZE];
+
+static struct ring tx_ring =
+{
+    tx_buff,
+    TX_RING_SIZE - 1,
+    0,
+    0
+};
+
+static unsigned char rx_buff [RX_RING_SIZE];
+
+static struct ring rx_ring =
+{
+    rx_buff,
+    RX_RING_SIZE - 1,
+    0,
+    0
+};
+
+static BOOL ring_empty (struct ring * ring)
+{
+    return ring->tail == ring->head;
+}
+
+static BOOL ring_full (struct ring * ring)
+{
+    return ring->tail == ((ring->head + 1) & ring->mask);
+}
+
+static unsigned char ring_get (struct ring * ring)
+{
+    unsigned char ch = ring->buff [ring->tail];
+
+    ring->tail = (ring->tail + 1) & ring->mask;
+
+    return ch;
+}
+
+static void ring_put (struct ring * ring, unsigned char ch)
+{
+    if (ring_full (ring))
+    {
+        ring->tail = (ring->tail + 1) & ring->mask;
+    }
+
+    ring->buff [ring->head] = ch;
+    ring->head = (ring->head + 1) & ring->mask;
+}
+
+unsigned char uart_getc (void)
+{
+    uintptr_t     gie;
+    unsigned char ch;
+
+    LOS_SemPend (s_rxsem, LOS_WAIT_FOREVER);
+    gie = LOS_IntLock ();       /* for SMP, spinlock is needed */
+    ch  = ring_get (&rx_ring);
+    LOS_IntRestore (gie);
+
+    return ch;
+}
+
+void uart_putc (unsigned char ch)
+{
+    BOOL      empty;
+    uintptr_t gie;
+
+    LOS_SemPend (s_txsem, LOS_WAIT_FOREVER);
+
+    gie = LOS_IntLock ();       /* for SMP, spinlock is needed */
+
+    empty = ring_empty (&tx_ring);
+
+    ring_put (&tx_ring, ch);
+
+    if (empty)
+    {
+        UCA0IE |= UCTXIE;
+    }
+
+    LOS_IntRestore (gie);
+}
+
+void uart_puts (unsigned char * str)
+{
+    unsigned char ch;
+
+    while ((ch = *str++) != '\0')
+    {
+        uart_putc (ch);
+
+        if (ch == '\n')
+        {
+            uart_putc ('\r');
+        }
+    }
+}
+
+static void uart_isr (uintptr_t arg)
+{
+    BOOL full;
+
+    (void) arg;
+
+    switch (__even_in_range (UCA0IV, 4))
+    {
+    case 0:
+        break;                                  // Vector 0 - no interrupt
+    case 2:                                     // Vector 2 - RXIFG
+        full = ring_full (&rx_ring);
+        ring_put (&rx_ring, UCA0RXBUF);
+        if (!full)
+        {
+            LOS_SemPost (s_rxsem);
+        }
+        break;
+    case 4:                                     // Vector 4 - TXIFG
+        if (ring_empty (&tx_ring))
+        {
+            UCA0IFG |= UCTXIFG;
+            UCA0IE  &= ~UCTXIE;
+            break;
+        }
+
+        UCA0TXBUF = ring_get (&tx_ring);
+
+        LOS_SemPost (s_txsem);
+
+        break;
+    default:
+        break;
+    }
+}
+
+UINT32 uart_init (void)
+{
+    UINT32 ret;
+
+    ret = LOS_HwiCreate (USCI_A0_VECTOR, 0, 0, uart_isr, 0);
+
+    if (ret != LOS_OK)
+    {
+        return ret;
+    }
+
+    ret = LOS_SemCreate (0, &s_rxsem);
+
+    if (ret != LOS_OK)
+    {
+        goto err_hwi_del;
+    }
+
+    ret = LOS_SemCreate (TX_RING_SIZE, &s_txsem);
+
+    if (ret != LOS_OK)
+    {
+        goto err_rxsem_del;
+    }
+
+    P3SEL     = 0x30;   /* set P3.4 = UCA0TXD/UCA0SIMO, P3.5 = UCA0RXD/UCA0SOMI */
+
+    /*
+     * To avoid unpredictable behavior, configure or reconfigure the USCI_A module
+     * only when UCSWRST is set.
+     *
+     * The recommended USCI initialization/reconfiguration process is:
+     * 1. Set UCSWRST.
+     * 2. Initialize all USCI registers with UCSWRST = 1
+     * 3. Configure ports.
+     * 4. Clear UCSWRST via software.
+     * 5. Enable interrupts (optional) via UCRXIE and/or UCTXIE.
+     */
+
+    UCA0CTL1  = UCSWRST;
+
+    /*
+     * (UCAxCTL1[7:6], UCSSELx) USCI clock source select:
+     * 00b = UCAxCLK (external USCI clock)
+     * 01b = ACLK
+     * 10b = SMCLK
+     * 11b = SMCLK
+     */
+
+    UCA0CTL1 |=  UCSSEL__ACLK;
+
+    /*
+     * set baudrate to 9600
+     *
+     * BRCLK UCBRx UCBRSx UCBRFx BAUDRATE
+     * 32768    27      2      0     1200
+     * 32768    13      6      0     2400
+     * 32768    6       7      0     4800
+     * 32768    3       3      0     9600
+     */
+
+    UCA0BR0  = 0x03;
+    UCA0BR1  = 0x00;
+    UCA0MCTL = UCBRS_3 + UCBRF_0;
+
+    UCA0CTL1 &= ~UCSWRST;
+    UCA0IE   |= UCRXIE;
+
+    return LOS_OK;
+
+err_hwi_del:
+    LOS_HwiDelete (USCI_A0_VECTOR);
+err_rxsem_del:
+    LOS_SemDelete (s_rxsem);
+    s_rxsem  = LOS_ERRNO_SEM_PTR_NULL;
+
+    return ret;
+}
+


### PR DESCRIPTION
1) added a new arch support (MSP430)
2) added a new target: Standard_msp430f5438a_taurus_v4.2
3) support TI CCS IDE (there is a README.md in the target folder descripting how to create CCS project)
4) arch/kernel/target code are ready for IAR use
5) the target contain a uart driver input/output with async interrupts

Please merge it as some customers want to use MSP430 target. This update have no affect to the ARM targets.