### PR TITLE
fix bug and pclint-warning

### DIFF
--- a/drivers/devices/wifi/marvell/tiny_aes.c
+++ b/drivers/devices/wifi/marvell/tiny_aes.c
@@ -547,9 +547,9 @@ void AES_CTR_xcrypt_buffer(struct AES_ctx* ctx, uint8_t* buf, uint32_t length)
       /* Increment Iv and handle overflow */
       for (bi = (AES_BLOCKLEN - 1); bi >= 0; --bi)
       {
-	/* inc will owerflow */
+	    /* inc will owerflow */
         if (ctx->Iv[bi] == 255)
-	{
+	    {
           ctx->Iv[bi] = 0;
           continue;
         } 

--- a/drivers/devices/wifi/marvell/wpa.c
+++ b/drivers/devices/wifi/marvell/wpa.c
@@ -39,6 +39,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 #include "tiny_aes.h"
 
 // base on mbedtls
@@ -55,6 +56,8 @@ void arc4_crypt_raw( arc4_context *ctx, unsigned char *buf, int buflen )
 {
     int i, x, y, a, b;
     unsigned char *m;
+
+    if(NULL == ctx || buf == NULL) return;
 
     x = ctx->x;
     y = ctx->y;
@@ -84,6 +87,8 @@ void ARC4_decrypt_keydata(const uint8_t *KEK, const uint8_t *key_iv, const uint8
     uint8_t dummy[256] = {0};
     uint8_t newkey[2][16];
 
+    if(NULL == KEK || NULL == key_iv || NULL == data || NULL == output) return;
+
     memcpy(newkey[0], key_iv, sizeof(newkey[0]));
     memcpy(newkey[1], KEK, sizeof(newkey[1]));
 
@@ -103,6 +108,9 @@ uint16_t AES_unwrap(const uint8_t *key, const uint8_t *data, uint16_t datalen, u
     uint8_t *r;
     uint16_t i, j, n, t;
     struct AES_ctx ctx;
+
+    if(NULL == key || NULL == data || NULL == output) return 0;
+    
     AES_init_ctx(&ctx, key);
 
     /* Initialize variables */
@@ -112,7 +120,7 @@ uint16_t AES_unwrap(const uint8_t *key, const uint8_t *data, uint16_t datalen, u
     memcpy(r, data + 8, datalen - 8);
 
     /* Compute intermediate values */
-    for (j = 5; j <= 5; j--)
+    for (j = 5; j >= 0; j--)
     {
         r = output + (n - 1) * 8;
         for (i = n; i >= 1; i--)
@@ -180,12 +188,14 @@ uint8_t hmac(const void *key, uint16_t keylen, const void *msg, uint16_t msglen,
 /* Using the md5 function provided by lwip to implement the HMAC_MD5 algorithm */
 uint8_t hmac_md5(const void *key, uint16_t keylen, const void *msg, uint16_t msglen, uint8_t output[HMAC_MD5_OUTPUTSIZE])
 {
+    if(NULL == key || NULL == msg) return 0;
     return hmac(key, keylen, msg, msglen, (HashFunction)md5, HMAC_MD5_BLOCKSIZE, output, HMAC_MD5_OUTPUTSIZE);
 }
 
 /* The HMAC_SHA1 algorithm is implemented using the sha1 function provided by lwip */
 uint8_t hmac_sha1(const void *key, uint16_t keylen, const void *msg, uint16_t msglen, uint8_t output[HMAC_SHA1_OUTPUTSIZE])
 {
+    if(NULL == key || NULL == msg) return 0;
     return hmac(key, keylen, msg, msglen, (HashFunction)sha1, HMAC_SHA1_BLOCKSIZE, output, HMAC_SHA1_OUTPUTSIZE);
 }
 
@@ -199,13 +209,15 @@ uint8_t pbkdf2_hmac_sha1(const void *password, uint16_t pwdlen, const void *salt
     uint16_t i;
     uint32_t j;
 
+    if(NULL == password || NULL == salt || NULL == dk) return 0;
+
     p = (uint8_t *)malloc(saltlen + 4);
     if (p == NULL)
         return 0;
     memcpy(p, salt, saltlen);
     memset(p + saltlen, 0, 2);
 
-    for (i = 1; dklen; i++)
+    for (i = 1; dklen > 0; i++)
     {
         // INT_32_BE(i)
         p[saltlen + 2] = i >> 8;
@@ -251,21 +263,24 @@ uint8_t pbkdf2_hmac_sha1(const void *password, uint16_t pwdlen, const void *salt
 // The parameter n is n over 8 in PRF-n
 uint8_t PRF(const void *k, uint16_t klen, const char *a, const void *b, uint16_t blen, void *output, uint8_t n)
 {
-    uint8_t alen = strlen(a);
+    uint8_t alen = 0;
     uint8_t buf[HMAC_SHA1_OUTPUTSIZE];
     uint8_t curr, i, *p, *q;
 
+    if(NULL == k || NULL == a || NULL == output) return 0;
+
+    alen = strlen(a);
     p = (uint8_t *)malloc(alen + blen + 2);
     if (p == NULL)
         return 0;
 
     q = (uint8_t *)output;
-    strcnpy((char *)p, a, alen); // application-specific text (including '\0')
+    strncpy((char *)p, a, alen+1); // application-specific text (including '\0')
     memcpy(p + alen + 1, b, blen); // special data
-    for (i = 0; n; i++)
+    for (i = 0; n > 0; i++)
     {
         p[alen + blen + 1] = i; // single byte counter
-        hmac_sha1(k, klen, p, alen + blen + 2, buf);
+        (void)hmac_sha1(k, klen, p, alen + blen + 2, buf);
 
         curr = (n < HMAC_SHA1_OUTPUTSIZE) ? n : HMAC_SHA1_OUTPUTSIZE;
         memcpy(q, buf, curr);

--- a/targets/Cloud_STM3210E_EVAL/Src/wiznet.c
+++ b/targets/Cloud_STM3210E_EVAL/Src/wiznet.c
@@ -303,7 +303,7 @@ int32_t wiznet_connect(const char* host, const char* port, int protocol)
     }
     
     id = wiz_get_unuse_linkid();
-    if(id < 0 || id > WIZ_MAX_SOCKET_NUM)
+    if(id < 0 || id >= WIZ_MAX_SOCKET_NUM)
     {
         WIZ_LOG("no vaild linkid for use(id = %ld)", id);
         return WIZ_FAILED;


### PR DESCRIPTION
1、修复wiznet已有的bug，w5500引起的pclint错误/警告未消除，部分接口与lwip中同名而引起
2、修复marvell wifi新引入的错误（消除pclint时引入的）
3、修复wpa.c中固有的bug
4、修复marvell wifi部分pclint告警，关于防内存泄漏、越界操作的告警已确认，暂时无法处理
    1）分配的堆内存，作为回调函数参数，已做释放处理
    2）越界操作1：对结构体中多个连续数组一次初始化，故意为之，不然分多次初始化
    3）越界操作2：结构体最后定义长度为1的数组，变长数组操作缓冲区的问题