### PR TITLE
update : add \r in the end of dprintf("\n")

### DIFF
--- a/examples/api/los_api_dynamic_mem.c
+++ b/examples/api/los_api_dynamic_mem.c
@@ -55,11 +55,11 @@ UINT32 Example_Dyn_Mem(VOID)
     uwRet = LOS_MemInit(pDynMem, MEM_DYN_SIZE);
     if (LOS_OK == uwRet)
     {
-        dprintf("mempool init ok!\n");
+        dprintf("mempool init ok! \r\n");
     }
     else
     {
-        dprintf("mempool init failed!\n");
+        dprintf("mempool init failed! \r\n");
         return LOS_NOK;
     }
 
@@ -67,33 +67,33 @@ UINT32 Example_Dyn_Mem(VOID)
     p_num = (UINT32 *)LOS_MemAlloc(pDynMem, 4);
     if (NULL == p_num)
     {
-        dprintf("mem alloc failed!\n");
+        dprintf("mem alloc failed! \r\n");
         return LOS_NOK;
     }
-    dprintf("mem alloc ok\n");
+    dprintf("mem alloc ok \r\n");
 
     /* assignment */
     *p_num = 828;
-    dprintf("*p_num = %d\n", *p_num);
+    dprintf("*p_num = %d \r\n", *p_num);
 
     /* mem free */
     uwRet = LOS_MemFree(pDynMem, p_num);
     if (LOS_OK == uwRet)
     {
-        dprintf("mem free ok!\n");
+        dprintf("mem free ok!\r\n");
         uwRet = LOS_InspectStatusSetByID(LOS_INSPECT_DMEM, LOS_INSPECT_STU_SUCCESS);
         if (LOS_OK != uwRet)
         {
-            dprintf("Set Inspect Status Err\n");
+            dprintf("Set Inspect Status Err \r\n");
         }
     }
     else
     {
-        dprintf("mem free failed!\n");
+        dprintf("mem free failed! \r\n");
         uwRet = LOS_InspectStatusSetByID(LOS_INSPECT_DMEM, LOS_INSPECT_STU_ERROR);
         if (LOS_OK != uwRet)
         {
-            dprintf("Set Inspect Status Err\n");
+            dprintf("Set Inspect Status Err \r\n");
         }
         return LOS_NOK;
     }

--- a/examples/api/los_api_event.c
+++ b/examples/api/los_api_event.c
@@ -65,25 +65,25 @@ VOID Example_Event(VOID)
      * timeout, WAITMODE to read event, timeout is 100 ticks,
      * if timeout, wake task directly
      */
-    dprintf("Example_Event wait event 0x%x \n",event_wait);
+    dprintf("Example_Event wait event 0x%x . \r\n",event_wait);
 
     uwEvent = LOS_EventRead(&example_event, event_wait, LOS_WAITMODE_AND, 100);
     if(uwEvent == event_wait)
     {
-        dprintf("Example_Event,read event :0x%x\n",uwEvent);
+        dprintf("Example_Event,read event :0x%x . \r\n",uwEvent);
         uwRet = LOS_InspectStatusSetByID(LOS_INSPECT_EVENT, LOS_INSPECT_STU_SUCCESS);
         if (LOS_OK != uwRet)
         {
-            dprintf("Set Inspect Status Err\n");
+            dprintf("Set Inspect Status Err. \r\n");
         }
     }
     else
     {
-        dprintf("Example_Event,read event timeout\n");
+        dprintf("Example_Event,read event timeout. \r\n");
         uwRet = LOS_InspectStatusSetByID(LOS_INSPECT_EVENT, LOS_INSPECT_STU_ERROR);
         if (LOS_OK != uwRet)
         {
-            dprintf("Set Inspect Status Err\n");
+            dprintf("Set Inspect Status Err. \r\n");
         }
     }
     return;
@@ -98,7 +98,7 @@ UINT32 Example_SndRcvEvent(VOID)
     uwRet = LOS_EventInit(&example_event);
     if(uwRet != LOS_OK)
     {
-        dprintf("init event failed .\n");
+        dprintf("init event failed .\r\n");
         return LOS_NOK;
     }
 
@@ -111,23 +111,23 @@ UINT32 Example_SndRcvEvent(VOID)
     uwRet = LOS_TaskCreate(&g_TestTaskID, &stTask1);
     if(uwRet != LOS_OK)
     {
-        dprintf("task create failed .\n");
+        dprintf("task create failed .\r\n");
         return LOS_NOK;
     }
 
     /* write event */
-    dprintf("Example_TaskEntry_Event write event .\n");
+    dprintf("Example_TaskEntry_Event write event .\r\n");
     uwRet = LOS_EventWrite(&example_event, event_wait);
     if(uwRet != LOS_OK)
     {
-        dprintf("event write failed .\n");
+        dprintf("event write failed .\r\n");
         return LOS_NOK;
     }
 
     /* clear event flag */
-    dprintf("EventMask:%d\n", example_event.uwEventID);
+    dprintf("EventMask:%d \r\n", example_event.uwEventID);
     LOS_EventClear(&example_event, ~example_event.uwEventID);
-    dprintf("EventMask:%d\n", example_event.uwEventID);
+    dprintf("EventMask:%d \r\n", example_event.uwEventID);
 
     return LOS_OK;
 }

--- a/examples/api/los_api_interrupt.c
+++ b/examples/api/los_api_interrupt.c
@@ -53,7 +53,7 @@ static VOID Example_Exti0_Init(VOID)
 
 static VOID User_IRQHandler(VOID)
 {
-    dprintf("\n User IRQ test\n");
+    dprintf("\r\n User IRQ test\r\n");
     //LOS_InspectStatusSetByID(LOS_INSPECT_INTERRUPT,LOS_INSPECT_STU_SUCCESS);
     return;
 }

--- a/examples/api/los_api_list.c
+++ b/examples/api/los_api_list.c
@@ -55,24 +55,24 @@ UINT32 Example_list(VOID)
     UINT32 uwRet = LOS_OK;
 
     /* init */
-    dprintf("initial......\n");
+    dprintf("initial...... \r\n");
     LOS_DL_LIST *head;
     head = (LOS_DL_LIST *)LOS_MemAlloc(m_aucSysMem0, sizeof(LOS_DL_LIST));
     if (head == NULL)
     {
-        dprintf("malloc failed\n");
+        dprintf("malloc failed \r\n");
         return LOS_NOK;
     }
 
     LOS_ListInit(head);
     if (!LOS_ListEmpty(head))
     {
-        dprintf("initial failed\n");
+        dprintf("initial failed \r\n");
         return LOS_NOK;
     }
 
     /* tail insert node*/
-    dprintf("node add and tail add......\n");
+    dprintf("node add and tail add......\r\n");
 
     LOS_DL_LIST *node1 = (LOS_DL_LIST *)LOS_MemAlloc(m_aucSysMem0, sizeof(LOS_DL_LIST));
     if (node1 == NULL)
@@ -84,7 +84,7 @@ UINT32 Example_list(VOID)
     LOS_DL_LIST *node2 = (LOS_DL_LIST *)LOS_MemAlloc(m_aucSysMem0, sizeof(LOS_DL_LIST));
     if (node2 == NULL)
     {
-        dprintf("malloc failed\n");
+        dprintf("malloc failed \r\n");
         LOS_MemFree(m_aucSysMem0, node1);
         return LOS_NOK;
     }
@@ -92,7 +92,7 @@ UINT32 Example_list(VOID)
     LOS_DL_LIST *tail = (LOS_DL_LIST *)LOS_MemAlloc(m_aucSysMem0, sizeof(LOS_DL_LIST));
     if (tail == NULL)
     {
-        dprintf("malloc failed\n");
+        dprintf("malloc failed \r\n");
         LOS_MemFree(m_aucSysMem0, node1);
         LOS_MemFree(m_aucSysMem0, node2);
         return LOS_NOK;
@@ -103,35 +103,35 @@ UINT32 Example_list(VOID)
     LOS_ListAdd(node1,node2);
     if ((node1->pstPrev == head) || (node2->pstPrev == node1))
     {
-        dprintf("add node success\n");
+        dprintf("add node success \r\n");
     }
 
     LOS_ListTailInsert(head, tail);
     if (tail->pstPrev == node2)
     {
-        dprintf("add tail success\n");
+        dprintf("add tail success \r\n");
     }
 
     /* delete node */
-    dprintf("delete node......\n");
+    dprintf("delete node......\r\n");
     LOS_ListDelete(node1);
     LOS_MemFree(m_aucSysMem0, node1);
     if (head->pstNext == node2)
     {
-        dprintf("delete node success\n");
+        dprintf("delete node success\r\n");
         uwRet = LOS_InspectStatusSetByID(LOS_INSPECT_LIST, LOS_INSPECT_STU_SUCCESS);
         if (LOS_OK != uwRet)
         {
-            dprintf("Set Inspect Status Err\n");
+            dprintf("Set Inspect Status Err\r\n");
         }
     }
     else
     {
-        dprintf("delete node error\n");
+        dprintf("delete node error\r\n");
         uwRet = LOS_InspectStatusSetByID(LOS_INSPECT_LIST, LOS_INSPECT_STU_ERROR);
         if (LOS_OK != uwRet)
         {
-            dprintf("Set Inspect Status Err\n");
+            dprintf("Set Inspect Status Err\r\n");
         }
     }
 

--- a/examples/api/los_api_msgqueue.c
+++ b/examples/api/los_api_msgqueue.c
@@ -67,7 +67,7 @@ static VOID *send_Entry(UINT32 uwParam)
         uwRet = LOS_QueueWrite(g_uwQueue, abuf, uwlen, 0);
         if(uwRet != LOS_OK)
         {
-            dprintf("send message failure,error:%x\n",uwRet);
+            dprintf("send message failure,error:%x \r\n",uwRet);
         }
 
         LOS_TaskDelay(5);
@@ -89,12 +89,12 @@ static VOID *recv_Entry(UINT32 uwParam)
         uwRet = LOS_QueueRead(g_uwQueue, &uwReadbuf, 24, 0);
         if (uwRet != LOS_OK)
         {
-            dprintf("recv message failure,error:%x\n",uwRet);
+            dprintf("recv message failure,error:%x \r\n",uwRet);
             break;
         }
         else
         {
-            dprintf("recv message:%s\n", (CHAR *)uwReadbuf);
+            dprintf("recv message:%s \r\n", (CHAR *)uwReadbuf);
             uwMsgCount++;
         }
 
@@ -107,14 +107,14 @@ static VOID *recv_Entry(UINT32 uwParam)
         (VOID)LOS_TaskDelay(1);
     }
 
-    dprintf("delete the queue success!\n");
+    dprintf("delete the queue success! \r\n");
 
     if (API_MSG_NUM == uwMsgCount)
     {
         uwRet = LOS_InspectStatusSetByID(LOS_INSPECT_MSG, LOS_INSPECT_STU_SUCCESS);
         if (LOS_OK != uwRet)
         {
-            dprintf("Set Inspect Status Err\n");
+            dprintf("Set Inspect Status Err \r\n");
         }
     }
     else
@@ -122,7 +122,7 @@ static VOID *recv_Entry(UINT32 uwParam)
         uwRet = LOS_InspectStatusSetByID(LOS_INSPECT_MSG, LOS_INSPECT_STU_ERROR);
         if (LOS_OK != uwRet)
         {
-            dprintf("Set Inspect Status Err\n");
+            dprintf("Set Inspect Status Err \r\n");
         }
     }
 
@@ -144,7 +144,7 @@ UINT32 Example_MsgQueue(VOID)
     uwRet = LOS_TaskCreate(&uwTask1, &stInitParam1);
     if (uwRet != LOS_OK)
     {
-        dprintf("create task1 failed!,error:%x\n",uwRet);
+        dprintf("create task1 failed!,error:%x \r\n",uwRet);
         return uwRet;
     }
 
@@ -153,7 +153,7 @@ UINT32 Example_MsgQueue(VOID)
     uwRet = LOS_TaskCreate(&uwTask2, &stInitParam1);
     if (uwRet != LOS_OK)
     {
-        dprintf("create task2 failed!,error:%x\n",uwRet);
+        dprintf("create task2 failed!,error:%x \r\n",uwRet);
         return uwRet;
     }
 
@@ -161,10 +161,10 @@ UINT32 Example_MsgQueue(VOID)
     uwRet = LOS_QueueCreate("queue", 5, &g_uwQueue, 0, 24);
     if (uwRet != LOS_OK)
     {
-        dprintf("create queue failure!,error:%x\n",uwRet);
+        dprintf("create queue failure!,error:%x \r\n",uwRet);
     }
 
-    dprintf("create the queue success!\n");
+    dprintf("create the queue success! \r\n");
     LOS_TaskUnlock();//unlock task schedue
 
     return LOS_OK;

--- a/examples/api/los_api_mutex.c
+++ b/examples/api/los_api_mutex.c
@@ -58,31 +58,31 @@ static VOID Example_MutexTask1(VOID)
 {
     UINT32 uwRet;
 
-    dprintf("task1 try to get mutex, wait 10 Tick.\n");
+    dprintf("task1 try to get mutex, wait 10 Tick. \r\n");
     /* get mux */
     uwRet = LOS_MuxPend(g_Testmux01, 10);
 
     if (uwRet == LOS_OK)
     {
-        dprintf("task1 get mutex g_Testmux01.\n");
+        dprintf("task1 get mutex g_Testmux01. \r\n");
         /* release mux */
         LOS_MuxPost(g_Testmux01);
         return;
     }
     else if (uwRet == LOS_ERRNO_MUX_TIMEOUT)
     {
-        dprintf("task1 timeout and try to get  mutex, wait forever.\n");
+        dprintf("task1 timeout and try to get  mutex, wait forever. \r\n");
         /* LOS_WAIT_FOREVER type get mux, LOS_MuxPend return until has been get mux */
         uwRet = LOS_MuxPend(g_Testmux01, LOS_WAIT_FOREVER);
         if (uwRet == LOS_OK)
         {
-            dprintf("task1 wait forever,got mutex g_Testmux01 success.\n");
+            dprintf("task1 wait forever,got mutex g_Testmux01 success. \r\n");
             /* release mux */
             LOS_MuxPost(g_Testmux01);
             uwRet = LOS_InspectStatusSetByID(LOS_INSPECT_MUTEX, LOS_INSPECT_STU_SUCCESS);
             if (LOS_OK != uwRet)
             {
-                dprintf("Set Inspect Status Err\n");
+                dprintf("Set Inspect Status Err \r\n");
             }
             return;
         }
@@ -94,21 +94,21 @@ static VOID Example_MutexTask2(VOID)
 {
     UINT32 uwRet;
 
-    dprintf("task2 try to get mutex, wait forever.\n");
+    dprintf("task2 try to get mutex, wait forever. \r\n");
     /* get mux */
     uwRet = LOS_MuxPend(g_Testmux01, LOS_WAIT_FOREVER);
     if(uwRet != LOS_OK)
     {
-        dprintf("task2 LOS_MuxPend failed .\n");
+        dprintf("task2 LOS_MuxPend failed . \r\n");
         return;
     }
 
-    dprintf("task2 get mutex g_Testmux01 and suspend 100 Tick.\n");
+    dprintf("task2 get mutex g_Testmux01 and suspend 100 Tick. \r\n");
 
     /* task delay 100 ticks */
     LOS_TaskDelay(100);
 
-    dprintf("task2 resumed and post the g_Testmux01\n");
+    dprintf("task2 resumed and post the g_Testmux01 \r\n");
     /* release mux */
     LOS_MuxPost(g_Testmux01);
     return;
@@ -135,7 +135,7 @@ UINT32 Example_MutexLock(VOID)
     uwRet = LOS_TaskCreate(&g_TestTaskID01, &stTask1);
     if (uwRet != LOS_OK)
     {
-        dprintf("task1 create failed .\n");
+        dprintf("task1 create failed . \r\n");
         return LOS_NOK;
     }
 
@@ -148,7 +148,7 @@ UINT32 Example_MutexLock(VOID)
     uwRet = LOS_TaskCreate(&g_TestTaskID02, &stTask2);
     if (uwRet != LOS_OK)
     {
-        dprintf("task2 create failed .\n");
+        dprintf("task2 create failed . \r\n");
         return LOS_NOK;
     }
 

--- a/examples/api/los_api_sem.c
+++ b/examples/api/los_api_sem.c
@@ -59,7 +59,7 @@ static VOID Example_SemTask1(VOID)
 {
     UINT32 uwRet;
 
-    dprintf("Example_SemTask1 try get sem g_usSemID ,timeout 10 ticks.\n");
+    dprintf("Example_SemTask1 try get sem g_usSemID ,timeout 10 ticks.\r\n");
     /* get sem, timeout is 10 ticks */
     uwRet = LOS_SemPend(g_usSemID, 10);
 
@@ -72,17 +72,17 @@ static VOID Example_SemTask1(VOID)
     /* timeout, get sem fail */
     if (LOS_ERRNO_SEM_TIMEOUT == uwRet)
     {
-        dprintf("Example_SemTask1 timeout and try get sem g_usSemID wait forever.\n");
+        dprintf("Example_SemTask1 timeout and try get sem g_usSemID wait forever.\r\n");
         /* get sem wait forever, LOS_SemPend return until has been get mux */
         uwRet = LOS_SemPend(g_usSemID, LOS_WAIT_FOREVER);
         if (LOS_OK == uwRet)
         {
-            dprintf("Example_SemTask1 wait_forever and got sem g_usSemID success.\n");
+            dprintf("Example_SemTask1 wait_forever and got sem g_usSemID success.\r\n");
             LOS_SemPost(g_usSemID);
             uwRet = LOS_InspectStatusSetByID(LOS_INSPECT_SEM, LOS_INSPECT_STU_SUCCESS);
             if (LOS_OK != uwRet)
             {
-                dprintf("Set Inspect Status Err\n");
+                dprintf("Set Inspect Status Err \r\n");
             }
             return;
         }
@@ -93,19 +93,19 @@ static VOID Example_SemTask1(VOID)
 static VOID Example_SemTask2(VOID)
 {
     UINT32 uwRet;
-    dprintf("Example_SemTask2 try get sem g_usSemID wait forever.\n");
+    dprintf("Example_SemTask2 try get sem g_usSemID wait forever.\r\n");
     /* wait forever get sem */
     uwRet = LOS_SemPend(g_usSemID, LOS_WAIT_FOREVER);
 
     if(LOS_OK == uwRet)
     {
-        dprintf("Example_SemTask2 get sem g_usSemID and then delay 20ticks .\n");
+        dprintf("Example_SemTask2 get sem g_usSemID and then delay 20ticks .\r\n");
     }
 
     /* task delay 20 ticks */
     LOS_TaskDelay(20);
 
-    dprintf("Example_SemTask2 post sem g_usSemID .\n");
+    dprintf("Example_SemTask2 post sem g_usSemID .\r\n");
     /* release sem */
     LOS_SemPost(g_usSemID);
 
@@ -133,7 +133,7 @@ UINT32 Example_Semphore(VOID)
     uwRet = LOS_TaskCreate(&g_TestTaskID01, &stTask1);
     if (uwRet != LOS_OK)
     {
-        dprintf("task1 create failed .\n");
+        dprintf("task1 create failed .\r\n");
         return LOS_NOK;
     }
 
@@ -146,12 +146,12 @@ UINT32 Example_Semphore(VOID)
     uwRet = LOS_TaskCreate(&g_TestTaskID02, &stTask2);
     if (uwRet != LOS_OK)
     {
-        dprintf("task2 create failed .\n");
+        dprintf("task2 create failed .\r\n");
 
         /* delete task 1 */
         if (LOS_OK != LOS_TaskDelete(g_TestTaskID01))
         {
-            dprintf("task1 delete failed .\n");
+            dprintf("task1 delete failed .\r\n");
         }
 
         return LOS_NOK;

--- a/examples/api/los_api_static_mem.c
+++ b/examples/api/los_api_static_mem.c
@@ -53,46 +53,46 @@ UINT32 Example_StaticMem(VOID)
     uwRet = LOS_MemboxInit(&pBoxMem[0], uwBoxSize, uwBlkSize);
     if (uwRet != LOS_OK)
     {
-        dprintf("Mem box init failed\n");
+        dprintf("Mem box init failed .\r\n");
         return LOS_NOK;
     }
     else
     {
-        dprintf("Mem box init ok!\n");
+        dprintf("Mem box init ok! .\r\n");
     }
 
     /* membox alloc */
     p_num = (UINT32*)LOS_MemboxAlloc(pBoxMem);
     if (NULL == p_num)
     {
-        dprintf("Mem box alloc failed!\n");
+        dprintf("Mem box alloc failed! .\r\n");
         return LOS_NOK;
     }
-    dprintf("Mem box alloc ok\n");
+    dprintf("Mem box alloc ok .\r\n");
     /* assignment */
     *p_num = 828;
-    dprintf("*p_num = %d\n", *p_num);
+    dprintf("*p_num = %d .\r\n", *p_num);	
     /* clear mem context */
     LOS_MemboxClr(pBoxMem, p_num);
-    dprintf("clear data ok\n *p_num = %d\n", *p_num);
+    dprintf("clear data ok \r\n *p_num = %d .\r\n", *p_num);
     /* membox free */
     uwRet = LOS_MemboxFree(pBoxMem, p_num);
     if (LOS_OK == uwRet)
     {
-        dprintf("Mem box free ok!\n");
+        dprintf("Mem box free ok! .\r\n");
         uwRet = LOS_InspectStatusSetByID(LOS_INSPECT_SMEM, LOS_INSPECT_STU_SUCCESS);
         if (LOS_OK != uwRet)
         {
-            dprintf("Set Inspect Status Err\n");
+            dprintf("Set Inspect Status Err .\r\n");
         }
     }
     else
     {
-        dprintf("Mem box free failed!\n");
+        dprintf("Mem box free failed! .\r\n");
         uwRet = LOS_InspectStatusSetByID(LOS_INSPECT_SMEM, LOS_INSPECT_STU_ERROR);
         if (LOS_OK != uwRet)
         {
-            dprintf("Set Inspect Status Err\n");
+            dprintf("Set Inspect Status Err .\r\n");
         }
     }
 

--- a/examples/api/los_api_systick.c
+++ b/examples/api/los_api_systick.c
@@ -48,9 +48,9 @@ VOID Example_TransformTime(VOID)
     UINT32 uwMs;
     UINT32 uwTick;
     uwTick = LOS_MS2Tick(10000);
-    dprintf("uwTick = %d \n",uwTick);
+    dprintf("uwTick = %d .\r\n",uwTick);
     uwMs = LOS_Tick2MS(100);
-    dprintf("uwMs = %d \n",uwMs);
+    dprintf("uwMs = %d .\r\n",uwMs);
 }
 
 UINT32 Example_GetTick(VOID)
@@ -62,19 +62,19 @@ UINT32 Example_GetTick(VOID)
     uwcyclePerTick  = LOS_CyclePerTickGet();
     if (0 != uwcyclePerTick)
     {
-        dprintf("LOS_CyclePerTickGet = %d \n", uwcyclePerTick);
+        dprintf("LOS_CyclePerTickGet = %d .\r\n", uwcyclePerTick);
     }
 
     uwTickCount1 = LOS_TickCountGet();
     if (0 != uwTickCount1)
     {
-        dprintf("LOS_TickCountGet = %d \n", (UINT32)uwTickCount1);
+        dprintf("LOS_TickCountGet = %d .\r\n", (UINT32)uwTickCount1);
     }
     LOS_TaskDelay(200);
     uwTickCount2 = LOS_TickCountGet();
     if (0 != uwTickCount2)
     {
-        dprintf("LOS_TickCountGet after delay = %d \n", (UINT32)uwTickCount2);
+        dprintf("LOS_TickCountGet after delay = %d .\r\n", (UINT32)uwTickCount2);
     }
 
     if ((uwTickCount2 - uwTickCount1) >= 200)
@@ -82,7 +82,7 @@ UINT32 Example_GetTick(VOID)
         uwRet = LOS_InspectStatusSetByID(LOS_INSPECT_SYSTIC, LOS_INSPECT_STU_SUCCESS);
         if (LOS_OK != uwRet)
         {
-            dprintf("Set Inspect Status Err\n");
+            dprintf("Set Inspect Status Err .\r\n");
         }
         return LOS_OK;
     }
@@ -91,7 +91,7 @@ UINT32 Example_GetTick(VOID)
         uwRet = LOS_InspectStatusSetByID(LOS_INSPECT_SYSTIC, LOS_INSPECT_STU_ERROR);
         if (LOS_OK != uwRet)
         {
-            dprintf("Set Inspect Status Err\n");
+            dprintf("Set Inspect Status Err .\r\n");
         }
         return LOS_NOK;
     }

--- a/examples/api/los_api_task.c
+++ b/examples/api/los_api_task.c
@@ -75,7 +75,7 @@ static UINT32 Example_TaskHi(VOID)
         uwRet = LOS_InspectStatusSetByID(LOS_INSPECT_TASK, LOS_INSPECT_STU_ERROR);
         if (LOS_OK != uwRet)
         {
-            dprintf("Set Inspect Status Err\n");
+            dprintf("Set Inspect Status Err.\r\n");
         }
         return LOS_NOK;
     }
@@ -85,13 +85,13 @@ static UINT32 Example_TaskHi(VOID)
     uwRet = LOS_InspectStatusSetByID(LOS_INSPECT_TASK, LOS_INSPECT_STU_SUCCESS);
     if (LOS_OK != uwRet)
     {
-        dprintf("Set Inspect Status Err\n");
+        dprintf("Set Inspect Status Err.\r\n");
     }
 
     /* delete self */
     if(LOS_OK != LOS_TaskDelete(g_uwTskHiID))
     {
-        dprintf("TaskHi delete failed .\n");
+        dprintf("TaskHi delete failed .\r\n");
         return LOS_NOK;
     }
 
@@ -122,7 +122,7 @@ static UINT32 Example_TaskLo(VOID)
         uwRet = LOS_InspectStatusSetByID(LOS_INSPECT_TASK, LOS_INSPECT_STU_ERROR);
         if (LOS_OK != uwRet)
         {
-            dprintf("Set Inspect Status Err\n");
+            dprintf("Set Inspect Status Err.\r\n");
         }
         return LOS_NOK;
     }
@@ -130,7 +130,7 @@ static UINT32 Example_TaskLo(VOID)
     /* delete self */
     if(LOS_OK != LOS_TaskDelete(g_uwTskLoID))
     {
-        dprintf("TaskLo delete failed .\n");
+        dprintf("TaskLo delete failed .\r\n");
         return LOS_NOK;
     }
 
@@ -174,7 +174,7 @@ UINT32 Example_TskCaseEntry(VOID)
         /* delete high prio task */
         if (LOS_OK != LOS_TaskDelete(g_uwTskHiID))
         {
-            dprintf("TaskHi delete failed .\n");
+            dprintf("TaskHi delete failed .\r\n");
         }
 
         LOS_TaskUnlock();

--- a/examples/api/los_api_timer.c
+++ b/examples/api/los_api_timer.c
@@ -54,8 +54,8 @@ static VOID Timer1_Callback(UINT32 arg)
 
     g_timercount1++;
     tick_last1 = (UINT32)LOS_TickCountGet();
-    dprintf("g_timercount1=%d\n", g_timercount1);
-    dprintf("tick_last1=%d\n", tick_last1);
+    dprintf("g_timercount1=%d .\r\n", g_timercount1);
+    dprintf("tick_last1=%d .\r\n", tick_last1);
 }
 
 static VOID Timer2_Callback(UINT32 arg)
@@ -65,12 +65,12 @@ static VOID Timer2_Callback(UINT32 arg)
 
     tick_last2 = (UINT32)LOS_TickCountGet();
     g_timercount2++;
-    dprintf("g_timercount2=%d\n", g_timercount2);
-    dprintf("tick_last2=%d\n", tick_last2);
+    dprintf("g_timercount2=%d .\r\n", g_timercount2);
+    dprintf("tick_last2=%d .\r\n", tick_last2);
     uwRet = LOS_InspectStatusSetByID(LOS_INSPECT_TIMER, LOS_INSPECT_STU_SUCCESS);
     if (LOS_OK != uwRet)
     {
-        dprintf("Set Inspect Status Err\n");
+        dprintf("Set Inspect Status Err .\r\n");
     }
 }
 
@@ -87,11 +87,11 @@ UINT32 Example_swTimer(VOID)
 #endif
     if (LOS_OK != uwRet)
     {
-        dprintf("create Timer1 failed\n");
+        dprintf("create Timer1 failed .\r\n");
     }
     else
     {
-        dprintf("create Timer1 success\n");
+        dprintf("create Timer1 success .\r\n");
     }
 
 #if (LOSCFG_BASE_CORE_SWTMR_ALIGN == YES)
@@ -101,21 +101,21 @@ UINT32 Example_swTimer(VOID)
 #endif
     if(LOS_OK != uwRet)
     {
-        dprintf("create Timer2 failed\n");
+        dprintf("create Timer2 failed .\r\n");
     }
     else
     {
-        dprintf("create Timer2 success\n");
+        dprintf("create Timer2 success .\r\n");
     }
 
     uwRet = LOS_SwtmrStart(id1);
     if (LOS_OK != uwRet)
     {
-        dprintf("start Timer1 failed\n");
+        dprintf("start Timer1 failed .\r\n");
     }
     else
     {
-        dprintf("start Timer1 sucess\n");
+        dprintf("start Timer1 sucess .\r\n");
     }
 
     (VOID)LOS_TaskDelay(200);
@@ -123,17 +123,17 @@ UINT32 Example_swTimer(VOID)
     uwRet = LOS_SwtmrStop(id1);
     if (LOS_OK != uwRet)
     {
-        dprintf("stop Timer1 failed\n");
+        dprintf("stop Timer1 failed .\r\n");
     }
     else
     {
-        dprintf("stop Timer1 sucess\n");
+        dprintf("stop Timer1 sucess .\r\n");
     }
 
     uwRet = LOS_SwtmrStart(id1);
     if (LOS_OK != uwRet)
     {
-        dprintf("start Timer1 failed\n");
+        dprintf("start Timer1 failed .\r\n");
     }
 
     (VOID)LOS_TaskDelay(1000);
@@ -142,21 +142,21 @@ UINT32 Example_swTimer(VOID)
     uwRet = LOS_SwtmrDelete(id1);
     if (LOS_OK != uwRet)
     {
-        dprintf("delete Timer1 failed\n");
+        dprintf("delete Timer1 failed .\r\n");
     }
     else
     {
-        dprintf("delete Timer1 sucess\n");
+        dprintf("delete Timer1 sucess .\r\n");
     }
 
     uwRet = LOS_SwtmrStart(id2);
     if (LOS_OK != uwRet)
     {
-        dprintf("start Timer2 failed\n");
+        dprintf("start Timer2 failed .\r\n");
     }
     else
     {
-        dprintf("start Timer2 success\n");
+        dprintf("start Timer2 success .\r\n");
     }
 
     (VOID)LOS_TaskDelay(1000);
@@ -164,13 +164,13 @@ UINT32 Example_swTimer(VOID)
     uwRet = LOS_SwtmrStop(id2);
     if (LOS_OK != uwRet)
     {
-        dprintf("stop Timer2 failed\n");
+        dprintf("stop Timer2 failed .\r\n");
     }
 
     uwRet = LOS_SwtmrDelete(id2);
     if (LOS_OK != uwRet)
     {
-        dprintf("delete Timer2 failed\n");
+        dprintf("delete Timer2 failed .\r\n");
     }
 
     return LOS_OK;

--- a/examples/api/los_demo_entry.c
+++ b/examples/api/los_demo_entry.c
@@ -157,7 +157,7 @@ VOID LOS_Demo_Entry(VOID)
 
     if (uwRet != LOS_OK)
     {
-        dprintf("Api demo test task create failed\n");
+        dprintf("Api demo test task create failed \r\n");
         return;
     }
     return;


### PR DESCRIPTION
更新：在examples目录中部分 .c 文件内 dprintf(“\n”) 增加  \r，避免使用 SecureCRT 等软件时 dprintf("\n")  换行后没有"回车"。