### PR TITLE
fix some bugs(memory-leak and wildpointer) and so on.

### DIFF
--- a/components/connectivity/agent_tiny/lwm2m_client/object_binary_app_data_container.c
+++ b/components/connectivity/agent_tiny/lwm2m_client/object_binary_app_data_container.c
@@ -438,6 +438,7 @@ lwm2m_object_t * get_binary_app_data_object(atiny_param_t* atiny_params)
             {
                 break;
             }
+            appObj->instanceList = LWM2M_LIST_ADD(appObj->instanceList, targetP); // to add first
             memset(targetP, 0, sizeof(plat_instance_t));
             get_resource_uri(BINARY_APP_DATA_OBJECT_ID, i, BINARY_APP_DATA_RES_ID, &uri);
             ret = atiny_add_rpt_uri(&uri, &targetP->header);
@@ -448,7 +449,6 @@ lwm2m_object_t * get_binary_app_data_object(atiny_param_t* atiny_params)
             }
             (void)atiny_set_max_rpt_cnt(&uri, MAX(MIN_SAVE_CNT, atiny_params->server_params.storing_cnt));
             targetP->shortID = i;
-            appObj->instanceList = LWM2M_LIST_ADD(appObj->instanceList, targetP);
         }
 
         if(i < BINARY_APP_DATA_OBJECT_INSTANCE_NUM)
@@ -481,7 +481,6 @@ static void free_binary_app_data_object_rpt(lwm2m_object_t * object)
     lwm2m_uri_t uri;
     while(cur)
     {
-
         get_resource_uri(object->objID, ((plat_instance_t *)cur)->shortID, BINARY_APP_DATA_RES_ID, &uri);
         (void)atiny_rm_rpt_uri(&uri);
         cur = cur->next;

--- a/components/connectivity/agent_tiny/mqtt_client/mqtt_client.c
+++ b/components/connectivity/agent_tiny/mqtt_client/mqtt_client.c
@@ -586,24 +586,20 @@ int device_info_dup(atiny_device_info_t* dest, atiny_device_info_t* src)
         ATINY_LOG(LOG_FATAL, "Invalid args");
         return -1;
     }
+    
+    device_info_member_free(dest);
 
     dest->client_id = atiny_strdup((const char *)(src->client_id));
     if(NULL == dest->client_id)
         goto device_info_dup_failed;
 
-    if(NULL != dest->user_name)
-    {
-        dest->user_name = atiny_strdup((const char *)(src->user_name));
-        if(NULL == dest->user_name)
-            goto device_info_dup_failed;
-    }
+    dest->user_name = atiny_strdup((const char *)(src->user_name));
+    if(NULL == dest->user_name)
+        goto device_info_dup_failed;
 
-    if(NULL != dest->password)
-    {
-        dest->password = atiny_strdup((const char *)(src->password));
-        if(NULL == dest->password)
-            goto device_info_dup_failed;
-    }
+    dest->password = atiny_strdup((const char *)(src->password));
+    if(NULL == dest->password)
+        goto device_info_dup_failed;
 
     dest->will_flag = src->will_flag;
 

--- a/components/connectivity/at_frame/at_api_interface.c
+++ b/components/connectivity/at_frame/at_api_interface.c
@@ -34,8 +34,6 @@
 
 #if defined(WITH_AT_FRAMEWORK)
 #include "at_api_interface.h"
-#include "atadapter.h"
-
 
 static at_adaptor_api  *gp_at_adaptor_api = NULL;
 
@@ -49,12 +47,12 @@ int32_t at_api_register(at_adaptor_api *api)
 	{
 		return gp_at_adaptor_api->init();
 	}
-	return AT_FAILED;
+	return -1;
 }
 
 int32_t at_api_connect(const char* host, const char* port, int proto)
 {
-    int32_t ret = AT_FAILED;
+    int32_t ret = -1;
 
 	if (gp_at_adaptor_api && gp_at_adaptor_api->connect)
 	{
@@ -69,7 +67,7 @@ int32_t at_api_send(int32_t id , const unsigned char* buf, uint32_t len)
 	{
 		return gp_at_adaptor_api->send(id, buf, len);
 	}
-	return AT_FAILED;
+	return -1;
 }
 
 int32_t at_api_recv(int32_t id, unsigned char* buf, size_t len)
@@ -78,7 +76,7 @@ int32_t at_api_recv(int32_t id, unsigned char* buf, size_t len)
 	{
 		return gp_at_adaptor_api->recv(id, buf, len);
 	}
-	return AT_FAILED;
+	return -1;
 }
 
 int32_t at_api_recv_timeout(int32_t id, unsigned char* buf, size_t len, uint32_t timeout)
@@ -87,7 +85,7 @@ int32_t at_api_recv_timeout(int32_t id, unsigned char* buf, size_t len, uint32_t
 	{
 		return gp_at_adaptor_api->recv_timeout(id, buf, len, timeout);
 	}
-	return AT_FAILED;
+	return -1;
 }
 
 int32_t at_api_close(int32_t fd)
@@ -96,7 +94,7 @@ int32_t at_api_close(int32_t fd)
 	{
 		return gp_at_adaptor_api->close(fd);
 	}
-	return AT_FAILED;
+	return -1;
 }
 
 #endif

--- a/components/connectivity/lwm2m/core/liblwm2m.c
+++ b/components/connectivity/lwm2m/core/liblwm2m.c
@@ -677,7 +677,7 @@ next_step:
             bootstrap_start(contextP);
             contextP->state = STATE_BOOTSTRAPPING;
             bootstrap_step(contextP, tv_sec, timeoutP);
-						break;
+			break;
         }
         else
 #endif

--- a/components/security/mbedtls/mbedtls_port/dtls_interface.c
+++ b/components/security/mbedtls/mbedtls_port/dtls_interface.c
@@ -292,6 +292,7 @@ void dtls_ssl_destroy(mbedtls_ssl_context* ssl)
     {
         mbedtls_ssl_config_free(conf);
         mbedtls_free(conf);
+        ssl->conf = NULL; //  need by mbedtls_debug_print_msg(), see mbedtls_ssl_free(ssl)
     }
 
     if (ctr_drbg)

--- a/drivers/devices/gprs/sim900a.c
+++ b/drivers/devices/gprs/sim900a.c
@@ -327,11 +327,8 @@ at_config at_user_conf = {
 
 at_adaptor_api at_interface = {
     .init = sim900a_ini,
-//    .get_id = NULL, /*get connect id, only in multiconnect*/
-    /*TCP or UDP connect*/
-    .connect = sim900a_connect,
-    /*send data, if no response, retrun error*/
-    .send = sim900a_send,
+    .connect = sim900a_connect, /*TCP or UDP connect*/
+    .send = sim900a_send, /*send data, if no response, retrun error*/
     .recv_timeout = sim900a_recv_timeout,
     .recv = sim900a_recv,
     .close = sim900a_close,/*close connect*/

--- a/drivers/devices/gprs/sim900a.h
+++ b/drivers/devices/gprs/sim900a.h
@@ -31,8 +31,8 @@
  * Import, export and usage of Huawei LiteOS in any manner by you shall be in compliance with such
  * applicable export control laws and regulations.
  *---------------------------------------------------------------------------*/
-#ifndef __USART2_H
-#define	__USART2_H
+#ifndef __SIM900A_H__
+#define __SIM900A_H__
 
 #include "atadapter.h"
 
@@ -70,5 +70,5 @@
 #define AT_DATAF_PREFIX_MULTI      "\r\n+RECEIVE"
 #define SIM900A_DELAY       LOS_TaskDelay
 
-#endif /* __USART2_H */
+#endif /* __SIM900A_H__ */
 


### PR DESCRIPTION
1、lwm2m实例对象应该先加入链表，否则入链前异常退出（eg: line448），后续无法释放内存
2、device_info_dup(...)拷贝前，目标设备如存在需先清除，此处处理异常
3、进一步抽象at_api_interface文件，去耦合
4、dtls_interface中内存释放后，指针未赋NULL，后续调试接口中，出现野指针操作
5、其它