### PR TITLE
fix error(add list) of lwm2m object.

### DIFF
--- a/components/connectivity/agent_tiny/lwm2m_client/object_binary_app_data_container.c
+++ b/components/connectivity/agent_tiny/lwm2m_client/object_binary_app_data_container.c
@@ -438,17 +438,18 @@ lwm2m_object_t * get_binary_app_data_object(atiny_param_t* atiny_params)
             {
                 break;
             }
-            appObj->instanceList = LWM2M_LIST_ADD(appObj->instanceList, targetP); // to add first
             memset(targetP, 0, sizeof(plat_instance_t));
             get_resource_uri(BINARY_APP_DATA_OBJECT_ID, i, BINARY_APP_DATA_RES_ID, &uri);
             ret = atiny_add_rpt_uri(&uri, &targetP->header);
             if(ret != ATINY_OK)
             {
                 ATINY_LOG(LOG_ERR, "atiny_add_rpt_uri fail %d", ret);
+                lwm2m_free(targetP);
                 break;
             }
             (void)atiny_set_max_rpt_cnt(&uri, MAX(MIN_SAVE_CNT, atiny_params->server_params.storing_cnt));
             targetP->shortID = i;
+            appObj->instanceList = LWM2M_LIST_ADD(appObj->instanceList, targetP);
         }
 
         if(i < BINARY_APP_DATA_OBJECT_INSTANCE_NUM)

--- a/components/connectivity/agent_tiny/lwm2m_client/object_security.c
+++ b/components/connectivity/agent_tiny/lwm2m_client/object_security.c
@@ -612,8 +612,6 @@ lwm2m_object_t * get_security_object(uint16_t serverId,atiny_param_t* atiny_para
             clean_security_object(securityObj);
             return NULL;
         }
-        // Add targetP to the list first, otherwise the next call to clean_security_object() will cause a memory leak
-        securityObj->instanceList = LWM2M_LIST_ADD(securityObj->instanceList, targetP);
 
         memset(targetP, 0, sizeof(security_instance_t));
         if((ins_flag&INS_IOT_SERVER_FLAG)&&(ins_flag&INS_BS_SERVER_FLAG))
@@ -637,6 +635,8 @@ lwm2m_object_t * get_security_object(uint16_t serverId,atiny_param_t* atiny_para
                 security_params_index = 1;
             }
         }
+        // After instance id is initialized
+        securityObj->instanceList = LWM2M_LIST_ADD(securityObj->instanceList, targetP);
 
         bsPskId = atiny_params->security_params[security_params_index].psk_Id;
         psk = atiny_params->security_params[security_params_index].psk;


### PR DESCRIPTION
1、回滚lwm2m实例对象加入链表的修改，并正确处理