### PR TITLE
bs fix some bugs

### DIFF
--- a/components/connectivity/agent_tiny/osadapter/atiny_socket.c
+++ b/components/connectivity/agent_tiny/osadapter/atiny_socket.c
@@ -433,7 +433,7 @@ int atiny_net_recv_timeout(void *ctx, unsigned char *buf, size_t len,
     tv.tv_sec  = timeout / 1000;
     tv.tv_usec = (timeout % 1000) * 1000;
 
-    ret = select(fd + 1, &read_fds, NULL, NULL, timeout == 0 ? NULL : &tv);
+   ret = select(fd + 1, &read_fds, NULL, NULL, &tv);
 
     if (ret == 0)
     {


### PR DESCRIPTION
server initiated bootstrap start triger timer for dtls shakehand and trigger the server bootstrap periodically.
output the timeout in lwm2m delay state.
when timeout is 0 select can not wait forever by return immediatly.