### PR TITLE
1. fixed use HAL driver framework cause wait condition dead loop

### DIFF
--- a/arch/arm/arm-m/src/los_hwi.c
+++ b/arch/arm/arm-m/src/los_hwi.c
@@ -283,6 +283,9 @@ void SysTick_Handler(void)
     {
         g_ullTickCount++;
     }
+#ifdef USE_HAL_DRIVER
+    HAL_IncTick();
+#endif /*USE_HAL_DRIVER*/
 }
 
 #endif /*(LOSCFG_PLATFORM_HWI == YES)*/


### PR DESCRIPTION
   HAL driver framework use tick calculater timeout value.
   
